### PR TITLE
feat: [#10] AnalyticsView 그래프 구현

### DIFF
--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -10,6 +10,13 @@
 		685D7B592AE38D1A00783433 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 685D7B582AE38D1A00783433 /* .swiftlint.yml */; };
 		685D7B5A2AE38D1A00783433 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 685D7B582AE38D1A00783433 /* .swiftlint.yml */; };
 		685D7B5F2AE3F3D000783433 /* WatchWorkoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B5E2AE3F3D000783433 /* WatchWorkoutManager.swift */; };
+		685D7B652AE529E800783433 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B642AE529E800783433 /* AnalyticsView.swift */; };
+		685D7B682AE52A2900783433 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B672AE52A2900783433 /* Data.swift */; };
+		685D7B6E2AE5396200783433 /* LightRectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B6D2AE5396200783433 /* LightRectangleView.swift */; };
+		685D7B732AE53DA000783433 /* BarGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B722AE53DA000783433 /* BarGraphView.swift */; };
+		685D7B752AE53DC400783433 /* LineGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B742AE53DC400783433 /* LineGraphView.swift */; };
+		685D7B772AE53DD700783433 /* BarMinMaxGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B762AE53DD700783433 /* BarMinMaxGraphView.swift */; };
+		685D7B792AE5432C00783433 /* CheckboxToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B782AE5432C00783433 /* CheckboxToggleStyle.swift */; };
 		BEB666C22AE4E16D0090195A /* StartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB666C12AE4E16D0090195A /* StartView.swift */; };
 		D3C500132AE36F3F00EFAEFF /* SoccerBeatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C500122AE36F3F00EFAEFF /* SoccerBeatApp.swift */; };
 		D3C500152AE36F3F00EFAEFF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C500142AE36F3F00EFAEFF /* ContentView.swift */; };
@@ -54,6 +61,13 @@
 		685D7B582AE38D1A00783433 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		685D7B5E2AE3F3D000783433 /* WatchWorkoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWorkoutManager.swift; sourceTree = "<group>"; };
 		685D7B602AE3F3E700783433 /* SoccerBeat Watch App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SoccerBeat Watch App.entitlements"; sourceTree = "<group>"; };
+		685D7B642AE529E800783433 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
+		685D7B672AE52A2900783433 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		685D7B6D2AE5396200783433 /* LightRectangleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightRectangleView.swift; sourceTree = "<group>"; };
+		685D7B722AE53DA000783433 /* BarGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarGraphView.swift; sourceTree = "<group>"; };
+		685D7B742AE53DC400783433 /* LineGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineGraphView.swift; sourceTree = "<group>"; };
+		685D7B762AE53DD700783433 /* BarMinMaxGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarMinMaxGraphView.swift; sourceTree = "<group>"; };
+		685D7B782AE5432C00783433 /* CheckboxToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxToggleStyle.swift; sourceTree = "<group>"; };
 		BEB666C12AE4E16D0090195A /* StartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartView.swift; sourceTree = "<group>"; };
 		D3C5000F2AE36F3F00EFAEFF /* SoccerBeat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SoccerBeat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C500122AE36F3F00EFAEFF /* SoccerBeatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoccerBeatApp.swift; sourceTree = "<group>"; };
@@ -97,6 +111,49 @@
 			path = WorkoutManager;
 			sourceTree = "<group>";
 		};
+		685D7B662AE52A2100783433 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				685D7B672AE52A2900783433 /* Data.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		685D7B6C2AE5394E00783433 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				685D7B6D2AE5396200783433 /* LightRectangleView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		685D7B702AE53D7E00783433 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				685D7B642AE529E800783433 /* AnalyticsView.swift */,
+				685D7B712AE53D8400783433 /* Graph */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		685D7B712AE53D8400783433 /* Graph */ = {
+			isa = PBXGroup;
+			children = (
+				685D7B722AE53DA000783433 /* BarGraphView.swift */,
+				685D7B742AE53DC400783433 /* LineGraphView.swift */,
+				685D7B762AE53DD700783433 /* BarMinMaxGraphView.swift */,
+			);
+			path = Graph;
+			sourceTree = "<group>";
+		};
+		685D7B7A2AE554DD00783433 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				685D7B782AE5432C00783433 /* CheckboxToggleStyle.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		BEB666BE2AE4E13E0090195A /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -136,6 +193,10 @@
 		D3C500112AE36F3F00EFAEFF /* SoccerBeat */ = {
 			isa = PBXGroup;
 			children = (
+				685D7B7A2AE554DD00783433 /* Extension */,
+				685D7B702AE53D7E00783433 /* View */,
+				685D7B6C2AE5394E00783433 /* Component */,
+				685D7B662AE52A2100783433 /* Data */,
 				FBCED9252AE3DF5900C57BF9 /* Info.plist */,
 				D3C500122AE36F3F00EFAEFF /* SoccerBeatApp.swift */,
 				D3C500142AE36F3F00EFAEFF /* ContentView.swift */,
@@ -333,9 +394,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				FBCED9202AE3D38900C57BF9 /* MyCardView.swift in Sources */,
+				685D7B682AE52A2900783433 /* Data.swift in Sources */,
+				685D7B6E2AE5396200783433 /* LightRectangleView.swift in Sources */,
+				685D7B772AE53DD700783433 /* BarMinMaxGraphView.swift in Sources */,
 				D3C500152AE36F3F00EFAEFF /* ContentView.swift in Sources */,
 				D3C500132AE36F3F00EFAEFF /* SoccerBeatApp.swift in Sources */,
+				685D7B752AE53DC400783433 /* LineGraphView.swift in Sources */,
+				685D7B652AE529E800783433 /* AnalyticsView.swift in Sources */,
 				FBCED9272AE3E5EF00C57BF9 /* ColorExtension.swift in Sources */,
+				685D7B792AE5432C00783433 /* CheckboxToggleStyle.swift in Sources */,
+				685D7B732AE53DA000783433 /* BarGraphView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -554,7 +622,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -587,7 +656,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SoccerBeat/SoccerBeat/Component/LightRectangleView.swift
+++ b/SoccerBeat/SoccerBeat/Component/LightRectangleView.swift
@@ -1,0 +1,47 @@
+//
+//  FlareRectangleView.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 10/22/23.
+//
+
+import SwiftUI
+
+struct LightRectangleView: View {
+    var backgroundColor: Color = .gray.opacity(0.2)
+    var intensity: CGFloat = 0.5
+    var gradient = Gradient(colors: [
+        Color.white,
+        Color.white,
+        Color.white.opacity(0.2),
+        Color.white
+    ])
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 20.0)
+                .fill(backgroundColor)
+                .frame(maxWidth: .infinity)
+                .overlay(
+                    ZStack(alignment: .topLeading) {
+                        LinearGradient(gradient: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
+                            .mask(
+                                RoundedRectangle(cornerRadius: 20.0)
+                            )
+                            .opacity(0.12)
+                        
+                        LinearGradient(gradient: gradient, startPoint: .leading, endPoint: .trailing)
+                            .mask(
+                                RoundedRectangle(cornerRadius: 20.0)
+                                    .strokeBorder(lineWidth: 1)
+                            )
+                    }
+                        .opacity(0.5)
+                )
+        }
+    }
+}
+
+#Preview {
+    LightRectangleView()
+}

--- a/SoccerBeat/SoccerBeat/Data/Data.swift
+++ b/SoccerBeat/SoccerBeat/Data/Data.swift
@@ -1,0 +1,80 @@
+//
+//  Data.swift
+//  iOSAnimationTest
+//
+//  Created by jose Yun on 10/21/23.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Fake data for graph. Later Should be deleted or substituted by data from HealthKit - Jose
+
+struct Series: Identifiable {
+    /// The name of the play.
+    let play: String
+
+    /// Average daily values for each weekday.
+    /// The `weekday` property is a `Date` that represents a weekday.
+    let values: [(day: Date, values: Int)]
+
+    /// The identifier for the series.
+    var id: String { play }
+}
+
+func date(year: Int, month: Int, day: Int = 1) -> Date {
+    Calendar.current.date(from: DateComponents(year: year, month: month, day: day)) ?? Date()
+}
+
+let SprintDatalast30Days = [
+    (day: date(year: 2022, month: 5, day: 8), values: 168),
+    (day: date(year: 2022, month: 5, day: 9), values: 117),
+    (day: date(year: 2022, month: 5, day: 10), values: 119),
+    (day: date(year: 2022, month: 5, day: 11), values: 106),
+    (day: date(year: 2022, month: 5, day: 12), values: 119),
+    (day: date(year: 2022, month: 5, day: 13), values: 109),
+    (day: date(year: 2022, month: 5, day: 14), values: 168),
+    (day: date(year: 2022, month: 5, day: 15), values: 106),
+    (day: date(year: 2022, month: 5, day: 16), values: 117),
+    (day: date(year: 2022, month: 5, day: 17), values: 109)
+]
+
+let DistanceDummyData: [Series] = [
+    .init(play: "", values: [
+        (day: date(year: 2022, month: 5, day: 2), values: 54),
+        (day: date(year: 2022, month: 5, day: 3), values: 42),
+        (day: date(year: 2022, month: 5, day: 4), values: 88),
+        (day: date(year: 2022, month: 5, day: 5), values: 49),
+        (day: date(year: 2022, month: 5, day: 6), values: 42),
+        (day: date(year: 2022, month: 5, day: 7), values: 125),
+        (day: date(year: 2022, month: 5, day: 8), values: 67)
+
+    ])
+]
+
+let SpeedDummyData: [Series] = [
+    .init(play: "", values: [
+        (day: date(year: 2022, month: 5, day: 2), values: 42),
+        (day: date(year: 2022, month: 5, day: 3), values: 54),
+        (day: date(year: 2022, month: 5, day: 4), values: 42),
+        (day: date(year: 2022, month: 5, day: 5), values: 88),
+        (day: date(year: 2022, month: 5, day: 6), values: 39),
+        (day: date(year: 2022, month: 5, day: 7), values: 49),
+        (day: date(year: 2022, month: 5, day: 8), values: 67)
+    ])
+]
+
+let HeartBeatlast12Months = [
+    (month: date(year: 2021, month: 7), values: 3952, dailyAverage: 127, dailyMin: 95, dailyMax: 194),
+    (month: date(year: 2021, month: 8), values: 4044, dailyAverage: 130, dailyMin: 96, dailyMax: 189),
+    (month: date(year: 2021, month: 9), values: 3930, dailyAverage: 131, dailyMin: 101, dailyMax: 184),
+    (month: date(year: 2021, month: 10), values: 4217, dailyAverage: 136, dailyMin: 96, dailyMax: 193),
+    (month: date(year: 2021, month: 11), values: 4006, dailyAverage: 134, dailyMin: 104, dailyMax: 202),
+    (month: date(year: 2021, month: 12), values: 3994, dailyAverage: 129, dailyMin: 96, dailyMax: 190),
+    (month: date(year: 2022, month: 1), values: 4202, dailyAverage: 136, dailyMin: 96, dailyMax: 203),
+    (month: date(year: 2022, month: 2), values: 3749, dailyAverage: 134, dailyMin: 98, dailyMax: 200),
+    (month: date(year: 2022, month: 3), values: 4329, dailyAverage: 140, dailyMin: 104, dailyMax: 218),
+    (month: date(year: 2022, month: 4), values: 4084, dailyAverage: 136, dailyMin: 93, dailyMax: 221),
+    (month: date(year: 2022, month: 5), values: 4559, dailyAverage: 147, dailyMin: 104, dailyMax: 208),
+    (month: date(year: 2022, month: 6), values: 1023, dailyAverage: 170, dailyMin: 120, dailyMax: 170)
+]

--- a/SoccerBeat/SoccerBeat/Extension/CheckboxToggleStyle.swift
+++ b/SoccerBeat/SoccerBeat/Extension/CheckboxToggleStyle.swift
@@ -1,0 +1,30 @@
+//
+//  CheckboxStyle.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 10/22/23.
+//
+
+import SwiftUI
+
+struct CheckboxToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button(action: {
+            configuration.isOn.toggle()
+        }, label: {
+            HStack {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4.0)
+                        .foregroundStyle(.white)
+                        .frame(width: 21, height: 21)
+                    if configuration.isOn {
+                        Image(systemName: "checkmark")
+                            .foregroundStyle(.cyan)
+                            .bold()
+                    }
+                }
+                configuration.label
+            }
+        })
+    }
+}

--- a/SoccerBeat/SoccerBeat/View/AnalyticsView.swift
+++ b/SoccerBeat/SoccerBeat/View/AnalyticsView.swift
@@ -1,0 +1,151 @@
+//
+//  AnalyticsView.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 10/22/23.
+//
+
+import SwiftUI
+import Charts
+
+struct AnalyticsView: View {
+    
+    @State var isShowingDistance: Bool = false
+    @State var isShowingSprint: Bool = false
+    @State var isShowingHeartRate: Bool = false
+    @State var isShowingSpeed: Bool = false
+    @State var isOverGraphs: Bool = false
+    
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.darkblue, .black], startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea(.all)
+            
+            VStack {
+                Spacer()
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("Hello, Son")
+                        Text("How you like")
+                        Text("that?")
+                    }
+                    Spacer()
+                }
+                .foregroundStyle(
+                    .linearGradient(colors: [.skyblue, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
+                .font(.custom("SFProText-HeavyItalic", size: 36))
+                .padding()
+                
+                Spacer()
+                
+                HStack {
+                    VStack(alignment: .leading) {
+                        Toggle(isOn: $isShowingSprint, label: {
+                            Text("스프린트 (FW)")
+                                .foregroundStyle(isOverGraphs ? .gray : .white)
+                                .opacity(0.8)
+                        })
+                        .toggleStyle(CheckboxToggleStyle())
+                        .disabled(isShowingSprint ? false : isOverGraphs)
+                        
+                        Toggle(isOn: $isShowingHeartRate, label: {
+                            Text("심박수 (DF)")
+                                .foregroundStyle(isOverGraphs ? .gray : .white)
+                                .opacity(0.8)
+                        })
+                        .toggleStyle(CheckboxToggleStyle())
+                        .disabled(isShowingHeartRate ? false : isOverGraphs)
+                    }
+                    
+                    VStack(alignment: .leading) {
+                        Toggle(isOn: $isShowingDistance, label: {
+                            Text("활동량 (MF)")
+                                .foregroundStyle(isOverGraphs ? .gray : .white)
+                                .opacity(0.8)
+                        })
+                        .toggleStyle(CheckboxToggleStyle())
+                        .disabled(isShowingDistance ? false : isOverGraphs)
+                        
+                        Toggle(isOn: $isShowingSpeed, label: {
+                            Text("최대 속도 (DF)")
+                                .foregroundStyle(isOverGraphs ? .gray : .white)
+                                .opacity(0.8)
+                        })
+                        .toggleStyle(CheckboxToggleStyle())
+                        .disabled(isShowingSpeed ? false : isOverGraphs)
+                    }
+                }.padding(.horizontal)
+                
+                VStack(alignment: .leading) {
+                    ZStack {
+                        LightRectangleView()
+                        if isShowingSprint {
+                            BarGraphView()
+                                .padding()
+                        }
+                        
+                        if isShowingDistance {
+                            LineGraphView(data: DistanceDummyData)
+                                .padding()
+                        }
+                        
+                        if isShowingHeartRate {
+                            BarMinMaxGraphView()
+                                .padding()
+                        }
+                        
+                        if isShowingSpeed {
+                            LineGraphView(color: .white)
+                                .padding()
+                        }
+                    }
+            
+                    HStack {
+                        FormattedRecord(recordType: "최고 기록")
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .overlay {
+                                LightRectangleView()
+                            }
+                        
+                        FormattedRecord(recordType: "최저 기록")
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .overlay {
+                                LightRectangleView()
+                            }
+                        
+                    }
+                }.padding()
+            }.padding()
+        }
+        .onChange(of: [isShowingDistance, isShowingSprint, isShowingHeartRate, isShowingSpeed]) { newValue in
+            if newValue.filter({ $0 == true }).count < 2 {
+                isOverGraphs = false
+            } else {
+                isOverGraphs = true
+            }
+        }
+    }
+}
+
+#Preview {
+    AnalyticsView()
+}
+
+struct FormattedRecord: View {
+    var recordType: String
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(recordType)
+                .font(.system(size: 10))
+            Text("2023.10.12")
+                .font(.system(size: 10))
+            Text("1.5km")
+                .font(.system(size: 14))
+                .italic()
+                .bold()
+                .padding(.top)
+        }
+    }
+}

--- a/SoccerBeat/SoccerBeat/View/Graph/BarGraphView.swift
+++ b/SoccerBeat/SoccerBeat/View/Graph/BarGraphView.swift
@@ -1,0 +1,26 @@
+//
+//  BarGraphView.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 10/22/23.
+//
+
+import SwiftUI
+import Charts
+
+struct BarGraphView: View {
+    var body: some View {
+            Chart(SprintDatalast30Days, id: \.day) {
+                BarMark(
+                    x: .value("Day", $0.day, unit: .day),
+                    y: .value("Values", $0.values)
+                ).foregroundStyle(Gradient(colors: [.cyan, .cyan, .white]))
+                    .cornerRadius(8.0)
+            }
+            .chartYAxis(.hidden)
+        }
+}
+
+#Preview {
+    BarGraphView()
+}

--- a/SoccerBeat/SoccerBeat/View/Graph/BarMinMaxGraphView.swift
+++ b/SoccerBeat/SoccerBeat/View/Graph/BarMinMaxGraphView.swift
@@ -1,0 +1,38 @@
+//
+//  BarMinMaxGraphView.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 10/22/23.
+//
+
+import SwiftUI
+import Charts
+
+struct BarMinMaxGraphView: View {
+    var body: some View {
+            Chart {
+                ForEach(HeartBeatlast12Months, id: \.month) {
+                    BarMark(
+                        x: .value("Month", $0.month, unit: .month),
+                        yStart: .value("Min Sales", $0.dailyMin),
+                        yEnd: .value("Max Sales", $0.dailyMax),
+                        width: .ratio(0.6)
+                    ).cornerRadius(16.5)
+                        .opacity(0.6)
+                    RectangleMark(
+                        x: .value("Month", $0.month, unit: .month),
+                        y: .value("Values", $0.dailyAverage),
+                        width: .ratio(0.6),
+                        height: .fixed(2)
+                    )
+                }
+                .foregroundStyle(.pink)
+                
+            }
+            .chartXAxis(.hidden)
+        }
+}
+
+#Preview {
+    BarMinMaxGraphView()
+}

--- a/SoccerBeat/SoccerBeat/View/Graph/LineGraphView.swift
+++ b/SoccerBeat/SoccerBeat/View/Graph/LineGraphView.swift
@@ -1,0 +1,40 @@
+//
+//  LineGraphView.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 10/22/23.
+//
+
+import SwiftUI
+import Charts
+
+struct LineGraphView: View {
+    var color: Color = Color.pink
+    var data: [Series] = SpeedDummyData
+    var body: some View {
+            Chart {
+                ForEach(data) { series in
+                    ForEach(series.values, id: \.day) { element in
+                        LineMark(
+                            x: .value("Day", element.day, unit: .day),
+                            y: .value("Values", element.values)
+                        )
+                    }
+                    .foregroundStyle(color)
+                    .symbol() { 
+                        Circle()
+                            .fill(color)
+                            .frame(width: 6, height: 6)
+                    }
+                }
+                .symbolSize(80)
+                .lineStyle(StrokeStyle(lineWidth: 1))
+            }
+            .chartXAxis(.hidden)
+            .chartLegend(.hidden)
+    }
+}
+
+#Preview {
+    LineGraphView()
+}


### PR DESCRIPTION
## 🐲 관련 이슈
#10 

## 🏃‍♂️ 구현/변경 사항
- AnalyticsView의 그래프를 구현했습니다.
- 제가 사용한 뷰는 뷰 폴더를 만들어 넣었습니다. 
- 컴포넌트를 만들어 사용했습니다.
- SwiftChart 를 사용해 세 가지 타입의 그래프를 구현했습니다. 
- 더미 데이터를 만들어 사용했습니다.
- 화면의 배경 설정과 NavigationTitle의 위치는 조정하지 않았습니다.

## 스크린샷

![1022GraphView](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/52576276/2c4e3c0a-43c7-41ff-85bb-c0d02a1fcadb)

## ✏️ ETC
- 구찌의 Color(init: hex) 가 올라오면 그래프의 색상을 변경할 예정입니다.
- 두 개 이상의 그래프가 선택되었을 때 알림이 뜨지 않고 회색 글씨로 선택지들이 변합니다. 
- 두 개의 그래프를 겹쳐보는 것도 기획단에서 같이 얘기해볼 수 있으면 좋겠습니다.

## 🙏To Reviewer
