### PR TITLE
feat: [#103] navigationlink 구현

### DIFF
--- a/SoccerBeat/Share/Utiles/Color+extension.swift
+++ b/SoccerBeat/Share/Utiles/Color+extension.swift
@@ -164,7 +164,7 @@ extension ShapeStyle where Self == LinearGradient {
     
     static var matchTotalSectionHeader: Self {
         let start = Color(hex: 0xFFFFFF)
-        let end = Color(hex: 0xFFFFFF7A)
+        let end = Color(hex: 0xFFFFFF).opacity(0.5)
         return .linearGradient(colors: [start, end],
                                startPoint: .leading, endPoint: .trailing)
     }

--- a/SoccerBeat/SoccerBeat/UI/LightRectangleView.swift
+++ b/SoccerBeat/SoccerBeat/UI/LightRectangleView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct LightRectangleView: View {
-    var backgroundColor: Color = .gray.opacity(0.2)
+    var backgroundColor: Color = .gray.opacity(0.3)
     var intensity: CGFloat = 0.5
     var gradient = Gradient(colors: [
         Color.white,

--- a/SoccerBeat/SoccerBeat/UI/Screens/AnalyticsDetailView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/AnalyticsDetailView.swift
@@ -11,7 +11,7 @@ enum GraphEnum {
     case distance
     case sprint
     case speed
-    case BPM
+    case heartrate
 }
 
 struct AnalyticsDetailView: View {
@@ -22,11 +22,11 @@ struct AnalyticsDetailView: View {
         case .distance:
             return .zone2Bpm
         case .sprint:
-            return .zone4Bpm
+            return .zone3Bpm
         case .speed:
             return .zone1Bpm
-        case .BPM:
-            return .zone3Bpm
+        case .heartrate:
+            return .zone4Bpm
         }
     }
     
@@ -38,7 +38,7 @@ struct AnalyticsDetailView: View {
             return "FW - sprint"
         case .speed:
             return "DF - speed"
-        case .BPM:
+        case .heartrate:
             return "Soccer BPM"
         }
     }
@@ -51,7 +51,7 @@ struct AnalyticsDetailView: View {
             return "스프린트 횟수 (FW)"
         case .speed:
             return "속도 (DF)"
-        case .BPM:
+        case .heartrate:
             return "심박수"
         }
     }

--- a/SoccerBeat/SoccerBeat/UI/Screens/AnalyticsView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/AnalyticsView.swift
@@ -7,7 +7,15 @@
 
 import SwiftUI
 
+enum ActivityEnum {
+    case distance
+    case sprint
+    case speed
+    case heartrate
+}
+
 struct AnalyticsView: View {
+    
     var body: some View {
         VStack(spacing: 20) {
             HStack {
@@ -20,87 +28,103 @@ struct AnalyticsView: View {
             VStack(spacing: 15) {
                 HStack {
                     VStack(alignment: .leading) {
-                        HStack {
-                            Image("Running")
-                                .resizable()
-                                .frame(width: 22, height: 22)
-                            Text("활동량 (MF)")
+                        NavigationLink { AnalyticsDetailView(graphType: .distance) } label: {
+                            ActivityComponent(activityType: .distance)
                         }
-                        Text("2.2 Km")
-                            .font(.custom("SFProText-HeavyItalic", size: 32))
-                            .foregroundStyle(.zone2Bpm)
-                    }
-                    Spacer()
-                    Image("ActivityGraph")
-                }
-                .padding()
-                .padding(.horizontal)
-                .overlay {
-                    LightRectangleView()
-                }
-                HStack {
-                    VStack(alignment: .leading) {
-                        HStack {
-                            Image("Running")
-                                .resizable()
-                                .frame(width: 22, height: 22)
-                            Text("스프린트 (FW)")
+                        NavigationLink { AnalyticsDetailView(graphType: .sprint) } label: {
+                            ActivityComponent(activityType: .sprint)
                         }
-                        Text("10 Times")
-                            .font(.custom("SFProText-HeavyItalic", size: 32))
-                            .foregroundStyle(.zone3Bpm)
-                    }
-                    Spacer()
-                    Image("SprintGraph")
-                }
-                .padding()
-                .padding(.horizontal)
-                .overlay {
-                    LightRectangleView()
-                }
-                HStack {
-                    VStack(alignment: .leading) {
-                        HStack {
-                            Image("Running")
-                                .resizable()
-                                .frame(width: 22, height: 22)
-                            Text("최고 속도 (DF)")
+                        NavigationLink { AnalyticsDetailView(graphType: .speed) } label: {
+                            ActivityComponent(activityType: .speed)
                         }
-                        Text("20 Km/h")
-                            .font(.custom("SFProText-HeavyItalic", size: 32))
-                            .foregroundStyle(.zone1Bpm)
-                    }
-                    Spacer()
-                    Image("MaxSpeedGraph")
-                }
-                .padding()
-                .padding(.horizontal)
-                .overlay {
-                    LightRectangleView()
-                }
-                HStack {
-                    VStack(alignment: .leading) {
-                        HStack {
-                            Image("Running")
-                                .resizable()
-                                .frame(width: 22, height: 22)
-                            Text("심박수")
+                        NavigationLink { AnalyticsDetailView(graphType: .heartrate) } label: {
+                            ActivityComponent(activityType: .heartrate)
                         }
-                        Text("180 Bpm")
-                            .font(.custom("SFProText-HeavyItalic", size: 32))
-                            .foregroundStyle(.zone4Bpm)
                     }
-                    Spacer()
-                    Image("HeartrateGraph")
                 }
-                .padding()
-                .padding(.horizontal)
-                .overlay {
-                    LightRectangleView()
-                }
-                
             }
-            .padding(.horizontal)
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct ActivityComponent: View {
+    
+    var activityType: ActivityEnum
+    
+    private var title: String {
+        switch activityType {
+        case .distance:
+            return "활동량 (MF)"
+        case .sprint:
+            return "스프린트 (FW)"
+        case .speed:
+            return "최고 속도 (DF)"
+        case .heartrate:
+            return "심박수"
+        }
+    }
+    
+    private var value: String {
+        switch activityType {
+        case .distance:
+            return "2.2 Km"
+        case .sprint:
+            return "10 Times"
+        case .speed:
+            return "20 Km/h"
+        case .heartrate:
+            return "180 Bpm"
+        }
+    }
+    
+    private var graphImage: String {
+        switch activityType {
+        case .distance:
+            return "ActivityGraph"
+        case .sprint:
+            return "SprintGraph"
+        case .speed:
+            return "MaxSpeedGraph"
+        case .heartrate:
+            return "HeartrateGraph"
+        }
+    }
+    
+    private var valueColor: LinearGradient {
+        switch activityType {
+        case .distance:
+            return .zone2Bpm
+        case .sprint:
+            return .zone3Bpm
+        case .speed:
+            return .zone1Bpm
+        case .heartrate:
+            return .zone4Bpm
+        }
+    }
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                HStack {
+                    Image("Running")
+                        .resizable()
+                        .frame(width: 22, height: 22)
+                    Text(title)
+                        .foregroundStyle(.white)
+                }
+                Text(value)
+                    .font(.custom("SFProText-HeavyItalic", size: 32))
+                    .foregroundStyle(valueColor)
+            }
+            Spacer()
+            Image(graphImage)
+        }
+        .padding()
+        .padding(.horizontal)
+        .overlay {
+            LightRectangleView()
         }
     }
 }
@@ -108,135 +132,3 @@ struct AnalyticsView: View {
 #Preview {
     AnalyticsView()
 }
-
-//import SwiftUI
-//import Charts
-//
-//struct AnalyticsView: View {
-//    
-//    var isBool = false
-//    @State var isShowingDistance: Bool = false
-//    @State var isShowingSprint: Bool = true
-//    @State var isShowingHeartRate: Bool = false
-//    @State var isShowingSpeed: Bool = false
-//    @State var showingText: String = "스프린트 (FW)"
-//    
-//    var body: some View {
-//        ZStack {
-//            VStack {
-//                HStack {
-//                    VStack(alignment: .leading, spacing: 0.0) {
-//                        Text("Hello, Son")
-//                        Text("How you like")
-//                        Text("that?")
-//                    }
-//                    .foregroundStyle(
-//                        .linearGradient(colors: [.skyblue, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
-//                    .font(.custom("SFProText-HeavyItalic", size: 36))
-//                    .kerning(-1.5)
-//                    .padding(.horizontal)
-//                    .padding(.leading, 10.0)
-//                    Spacer()
-//                }
-//                .padding(.top, 30)
-//                .padding(.bottom)
-//                
-//                Spacer()
-//                
-//                HStack {
-//                    VStack(alignment: .leading) {
-//                        CheckboxToggleStyle(isOn: $isShowingSprint, showingText: $showingText, text: "스프린트 (FW)")
-//                        CheckboxToggleStyle(isOn: $isShowingHeartRate, showingText: $showingText, text: "심박수 (DF)")
-//                    }
-//                    
-//                    VStack(alignment: .leading) {
-//                        CheckboxToggleStyle(isOn: $isShowingDistance, showingText: $showingText, text: "활동량 (MF)")
-//                        CheckboxToggleStyle(isOn: $isShowingSpeed, showingText: $showingText, text: "최대 속도 (DF)")
-//                    }
-//                }
-//                
-//                VStack(alignment: .leading) {
-//                    ZStack {
-//                        LightRectangleView()
-//                        if isShowingSprint {
-//                            BarMinMaxGraphView(color: Gradient(colors: [Color(hex:  "0EB7FF"), .white]), data: SprintDatalast30Days)
-//                                .padding()
-//                        }
-//                        
-//                        if isShowingDistance {
-//                            LineGraphView(color: Color(hex: "FF007A"), data: DistanceDummyData)
-//                                .padding()
-//                        }
-//                        
-//                        if isShowingHeartRate {
-//                            BarMinMaxGraphView(color: Gradient(colors:[Color(hex: "FF007A")]), data: HeartBeatlast12Months)
-//                                .padding()
-//                        }
-//                        
-//                        if isShowingSpeed {
-//                            LineGraphView(color: .white)
-//                                .padding()
-//                        }
-//                    }
-//                    
-//                    HStack {
-//                        FormattedRecord(recordType: "최고 기록")
-//                            .frame(maxWidth: .infinity)
-//                            .padding()
-//                            .overlay {
-//                                LightRectangleView()
-//                            }
-//                        
-//                        FormattedRecord(recordType: "최저 기록")
-//                            .frame(maxWidth: .infinity)
-//                            .padding()
-//                            .overlay {
-//                                LightRectangleView()
-//                            }
-//                        
-//                    }
-//                }.padding(.horizontal)
-//                    .onChange(of: [isShowingDistance, isShowingSpeed, isShowingSprint, isShowingHeartRate] ) { newValue in
-//                        disableAll(text: showingText)
-//                        // activate only one selection
-//                    }
-//            }
-//        }
-//    }
-//    
-//    func disableAll(text: String) {
-//        
-//        self.isShowingSpeed = false
-//        self.isShowingSprint = false
-//        self.isShowingHeartRate = false
-//        self.isShowingDistance = false
-//        if text == "활동량 (MF)" {
-//            isShowingDistance = true
-//        } else if text == "최대 속도 (DF)" {
-//            isShowingSpeed = true
-//        } else if text == "심박수 (DF)" {
-//            isShowingHeartRate = true
-//        } else {
-//            isShowingSprint = true
-//        }
-//    }
-//}
-//
-
-//
-//struct FormattedRecord: View {
-//    var recordType: String
-//    var body: some View {
-//        VStack(alignment: .leading) {
-//            Text(recordType)
-//                .font(.system(size: 10))
-//            Text("2023.10.12")
-//                .font(.system(size: 10))
-//            Text("1.5km")
-//                .font(.system(size: 14))
-//                .italic()
-//                .bold()
-//                .padding(.top)
-//        }
-//    }
-//}

--- a/SoccerBeat/SoccerBeat/UI/Screens/ContentView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/ContentView.swift
@@ -9,31 +9,33 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        ScrollView {
-            ZStack {
-                Image("BackgroundPattern")
-                    .resizable()
-                    .scaledToFit()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(height: 0)
-                
-                VStack {
-                    MyCardView()
+        NavigationStack {
+            ScrollView {
+                ZStack {
+                    Image("BackgroundPattern")
+                        .resizable()
+                        .scaledToFit()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(height: 0)
                     
-                    Spacer()
-                        .frame(height: 114)
-                    
-                    
-                    MatchRecapView()
-                    
-                    Spacer()
-                        .frame(height: 60)
-                    
-                    AnalyticsView()
-                    
-                    Spacer()
-                        .frame(height: 60)
-                    
+                    VStack {
+                        
+                        MyCardView()
+                        
+                        Spacer()
+                            .frame(height: 114) 
+                        
+                        MatchRecapView()
+                        
+                        Spacer()
+                            .frame(height: 60)
+                        
+                        AnalyticsView()
+                        
+                        Spacer()
+                            .frame(height: 60)
+                        
+                    }
                 }
             }
         }

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchDetailView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchDetailView.swift
@@ -21,7 +21,8 @@ struct MatchDetailView: View {
                 VStack {
                     MatchDetailView01()
                     MatchDetailView02()
-                    MatchDetailView03()
+// MARK: 추후 HeartRate 추가
+//                    MatchDetailView03()
                     MatchDetailView04()
                 }
             }

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchRecapView.swift
@@ -33,61 +33,51 @@ class MatchItemData: ObservableObject {
 struct MatchRecapView: View {
     @ObservedObject var matchItemData = MatchItemData()
     @State var showingMatchDetail = false
-    @State var path: [NavigationStackViewType] = []
-    
-    enum NavigationStackViewType {
-        case firstView
-        case secondView
-    }
     
     var body: some View {
-//        NavigationStack(path: $path) {
-            VStack(spacing: 10) {
-                HStack {
-                    VStack(alignment: .leading, spacing: 0.0) {
-                        Text("Hello, Son")
-                        Text("Your archive")
-                    }
-                    .foregroundStyle(
-                        .linearGradient(colors: [.hotpink, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
-                    .font(.custom("SFProText-HeavyItalic", size: 36))
-                    .kerning(-1.5)
-                    .padding(.leading, 10)
-                    Spacer()
+        VStack(spacing: 10) {
+            HStack {
+                VStack(alignment: .leading, spacing: 0.0) {
+                    Text("Hello, Son")
+                    Text("Your archive")
                 }
-                .padding(.top, 30)
-                
+                .foregroundStyle(
+                    .linearGradient(colors: [.hotpink, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
+                .font(.custom("SFProText-HeavyItalic", size: 36))
+                .kerning(-1.5)
+                .padding(.leading, 10)
                 Spacer()
-                    .frame(height: 60)
-                
-                HStack {
-                    Text("최근 경기 기록")
-                        .font(.custom("NotoSansDisplay-BlackItalic", size: 24))
-                    Spacer()
-                    Button(action: { path.append(.firstView) }) {
-                        Text("모든 기록 보기 +")
-                            .foregroundStyle(.white)
-                            .font(.custom("NotoSansDisplay-BlackItalic", size: 14))
-                    }
+            }
+            .padding(.top, 30)
+            
+            Spacer()
+                .frame(height: 60)
+            
+            HStack {
+                Text("최근 경기 기록")
+                    .font(.custom("NotoSansDisplay-BlackItalic", size: 24))
+                Spacer()
+                NavigationLink {
+                    MatchTotalView()
+                } label: {
+                    Text("모든 기록 보기 +")
                 }
-                .padding(.horizontal)
-                VStack {
-                    ForEach(matchItemData.matchitems.prefix(3), id: \.self) { matchDetail in
-                            MatchListItemView(matchDetail: matchDetail)
-                            .padding(.vertical, 5)
-                    }
-                }
+                .foregroundStyle(.white)
+                .font(.custom("NotoSansDisplay-BlackItalic", size: 14))
             }
             .padding(.horizontal)
-//            .navigationDestination(for: NavigationStackViewType.self) { navigationStackViewType in
-//                switch navigationStackViewType {
-//                case .firstView:
-//                    AnalyticsDetailView(graphType: .BPM)
-//                case .secondView:
-//                    MatchDetailView()
-//                }
-//            }
-//        }
+            VStack {
+                ForEach(matchItemData.matchitems.prefix(3), id: \.self) { matchDetail in
+                    NavigationLink {
+                        MatchDetailView()
+                    } label: {
+                        MatchListItemView(matchDetail: matchDetail)
+                    }
+                    .padding(.vertical, 10)
+                }
+            }
+        }
+        .padding(.horizontal)
     }
 }
 
@@ -96,6 +86,7 @@ struct MatchListItemView: View {
     
     var body: some View {
         ZStack {
+            LightRectangleView()
             HStack {
                 Spacer ()
                 
@@ -138,9 +129,6 @@ struct MatchListItemView: View {
                 Spacer()
             }
             .padding(.vertical, 10)
-            .overlay {
-                LightRectangleView()
-            }
         }
     }
 }
@@ -159,8 +147,3 @@ struct MatchDetail: Identifiable, Hashable {
 #Preview {
     MatchRecapView()
 }
-
-//#Preview {
-//    let detail = MatchItemData().matchitems[0]
-//    return MatchListItemView(matchDetail: detail)
-//}

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchTotalView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchTotalView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MatchTotalView: View {
     @StateObject private var matchData = MatchItemData()
-    let userName = "Gucci"
+    let userName = "Son"
     
     var body: some View {
         ScrollView {
@@ -30,9 +30,7 @@ struct MatchTotalView: View {
                     ForEach(matchData.monthly[monthDate, default: []]) { matchDetail in
                         
                         NavigationLink {
-                            // TEMP: MatchDetailView
-                            Text("스프린트 개수: \(matchDetail.sprint)")
-                                .navigationTitle(matchDetail.date)
+                            MatchDetailView()
                         } label: {
                             MatchListItemView(matchDetail: matchDetail)
                                 .padding(10)
@@ -74,7 +72,5 @@ extension MatchTotalView {
 }
 
 #Preview {
-    NavigationStack {
         MatchTotalView()
-    }
 }


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #103 

## 🏃‍♂️ 구현/변경 사항
- ContentView에 navigationstack을 적용하였습니다.
- navigationlink로 뷰 연결 하였습니다.
- MatchDetailView heartbeat 주석처리 하였습니다.
- AnalyticsView enum으로 나눴습니다.

## 📷 스크린샷
<img width="316" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/106143629/52f27fa1-1c35-4a8e-ac11-24f46e368181">
<img width="323" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/106143629/1caed570-1883-4d77-b20c-b8f1beb83e57">


## ✏️  ETC
- 추후 back 버튼 커스텀으로 변경 예정입니다.

## 🙏To Reviewer
