### PR TITLE
feat: [#114] 경기 종료시 route 정보 저장

### DIFF
--- a/SoccerBeat/SoccerBeat Watch App/View/PrecountView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/View/PrecountView.swift
@@ -56,9 +56,12 @@ struct PrecountView: View {
                 // to Session Page
                 SessionPagingView()
                     .navigationBarBackButtonHidden()
-            }.onDisappear {
+            }
+            .onChange(of: count) { newCount in
                 // MARK: - Session Start
-                workoutManager.startWorkout()
+                if newCount < 2 {
+                    workoutManager.startWorkout()
+                }
             }
         }
     }

--- a/SoccerBeat/SoccerBeat Watch App/View/StartPauseControll/StartView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/View/StartPauseControll/StartView.swift
@@ -13,9 +13,7 @@ struct StartView: View {
     var body: some View {
         VStack {
             if !workoutManager.showingPrecount {
-                Button(action: { workoutManager.showingPrecount.toggle()
-                    print(workoutManager.showingPrecount)
-                } ) {
+                Button(action: {workoutManager.showingPrecount.toggle()}){
                     Image(.startButton)
                 }
             } else {

--- a/SoccerBeat/SoccerBeat Watch App/View/SummaryView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/View/SummaryView.swift
@@ -44,8 +44,7 @@ struct SummaryView: View {
                 }
             }
             .onAppear {
-                print(
-                workoutManager.workout?.totalEnergyBurned!)
+                print("Burned Calories: \(workoutManager.workout?.totalEnergyBurned ?? nil)")
             }
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -413,7 +413,6 @@ extension WorkoutManager: CLLocationManagerDelegate {
     
     private func startLocationUpdates() {
         locationManager.requestWhenInUseAuthorization()
-        locationManager.requestAlwaysAuthorization()
         locationManager.startUpdatingLocation()
     }
     

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -36,7 +36,6 @@ class WorkoutManager: NSObject, ObservableObject {
     var energy: Double = 0
     
     let sprintSpeed: Double = 5.5556 // modify it to test code
-//    let sprintSpeed: Double = 1.0 // modify it to test code
         
     var isSprint: Bool = false
     var maxSpeed: Double = 0.0
@@ -169,7 +168,6 @@ class WorkoutManager: NSObject, ObservableObject {
         
         let nowDate: Date = Date()
         
-        let speed = Measurement(value: self.maxSpeed, unit: UnitSpeed.kilometersPerHour).formatted(.measurement(width: .narrow, usage: .general))
         
         let dataSample: HKQuantitySample = HKQuantitySample(type: HKQuantityType(.runningSpeed), quantity: HKQuantity(unit:HKUnit.init(from: "m/s"), doubleValue: self.maxSpeed), start: nowDate, end: nowDate, metadata: ["MaxSpeed": Double(Int(self.maxSpeed * 100.rounded()))/100 , "SprintCount": self.sprint, "MinHeartRate": saveMinHeartRate == 200 ? 0 : saveMinHeartRate, "MaxHeartRate": saveMaxHeartRate, "Distance": (Double(Int(self.distance/1000 * 100 ))) / 100, "Calorie": Double(Int(self.energy * 100.rounded()))/100])
         
@@ -358,8 +356,6 @@ extension WorkoutManager: CLLocationManagerDelegate {
             location.horizontalAccuracy <= 20.0
         }
         
-        // TODO: - print 문 지우기
-
         guard !filteredLocations.isEmpty else {
             routeBuilder?.insertRouteData(locations, completion: { _, _ in
             })

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -168,8 +168,19 @@ class WorkoutManager: NSObject, ObservableObject {
         
         let nowDate: Date = Date()
         
+        let metadata: [String: Any] = [
+            "MaxSpeed": Double(Int(self.maxSpeed * 100.rounded()))/100 ,
+            "SprintCount": self.sprint,
+            "MinHeartRate": saveMinHeartRate,
+            "MaxHeartRate": saveMaxHeartRate,
+            "Distance": (Double(Int(self.distance/1000 * 100 ))) / 100,
+            "Calorie": Double(Int(self.energy * 100.rounded()))/100
+          ]
         
-        let dataSample: HKQuantitySample = HKQuantitySample(type: HKQuantityType(.runningSpeed), quantity: HKQuantity(unit:HKUnit.init(from: "m/s"), doubleValue: self.maxSpeed), start: nowDate, end: nowDate, metadata: ["MaxSpeed": Double(Int(self.maxSpeed * 100.rounded()))/100 , "SprintCount": self.sprint, "MinHeartRate": saveMinHeartRate == 200 ? 0 : saveMinHeartRate, "MaxHeartRate": saveMaxHeartRate, "Distance": (Double(Int(self.distance/1000 * 100 ))) / 100, "Calorie": Double(Int(self.energy * 100.rounded()))/100])
+        let dataSample: HKQuantitySample = HKQuantitySample(type: HKQuantityType(.runningSpeed),
+                                                            quantity: HKQuantity(unit:HKUnit.init(from: "m/s"),
+                                                                                 doubleValue: self.maxSpeed),
+                                                            start: nowDate, end: nowDate, metadata: metadata)
         
         self.healthStore.save(dataSample, withCompletion: { (success, error) in
             if (error != nil) {

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -105,7 +105,8 @@ class WorkoutManager: NSObject, ObservableObject {
         builder?.beginCollection(withStart: startDate) { (_, _) in
             // The workout has started.
         }
-        locationManager.desiredAccuracy = locationManager.accuracyAuthorization == .fullAccuracy 
+        
+        locationManager.desiredAccuracy = locationManager.accuracyAuthorization == .fullAccuracy
         ? kCLLocationAccuracyBestForNavigation
         : kCLLocationAccuracyBest
         

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -187,18 +187,6 @@ class WorkoutManager: NSObject, ObservableObject {
               NSLog("error occurred saving water data")
             }
           })
-        
-        if let workout = self.workout {
-            routeBuilder?.finishRoute(with: self.workout!, metadata: nil) { (newRoute, error) in
-                guard newRoute != nil else {
-                    // Handle any errors here.
-                    return
-                }
-                // Optional: Do something with the route here.
-                self.stopLocationUpdates()
-            }
-        }
-        
     }
     
     // MARK: - BPM
@@ -326,6 +314,17 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
                     DispatchQueue.main.async {
                         self.workout = workout
                     }
+            builder?.finishWorkout { (workout, error) in
+                if let error {
+                    NSLog("Failed Builder FinishWorkkout")
+                } else {
+                    guard let workout else { return }
+                    self.workout = workout
+                    self.routeBuilder?.finishRoute(with: workout, metadata: nil, completion: { hkRoute, routeError in
+                        if routeError == nil, let route = hkRoute {
+                            NSLog(route.debugDescription)
+                        }
+                    })
                 }
 
             }

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -302,18 +302,23 @@ class WorkoutManager: NSObject, ObservableObject {
 extension WorkoutManager: HKWorkoutSessionDelegate {
     func workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState,
                         from fromState: HKWorkoutSessionState, date: Date) {
+        NSLog("WorkOutSession 변화 감지: \(toState)")
         DispatchQueue.main.async {
             self.running = toState == .running
         }
         
         // Wait for the session to transition states before ending the builder.
+        /// 종료시에도 여기가 불리지 않는 경우가 존재
         if toState == .ended {
             
             builder?.endCollection(withEnd: date) { (success, error) in
-                self.builder?.finishWorkout { (workout, error) in
-                    DispatchQueue.main.async {
-                        self.workout = workout
-                    }
+                if success {
+                    NSLog("Finished Builder endCollection")
+                } else {
+                    NSLog("Failed Builder endCollection")
+                }
+            }
+            
             builder?.finishWorkout { (workout, error) in
                 if let error {
                     NSLog("Failed Builder FinishWorkkout")
@@ -326,9 +331,7 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
                         }
                     })
                 }
-
             }
-        
         }
     }
     

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -262,7 +262,6 @@ class WorkoutManager: NSObject, ObservableObject {
                 self.energy = statistics.sumQuantity()?.doubleValue(for: HKUnit(from: "kcal")) ?? 0
             default:
                 return
-                
             }
         }
     }
@@ -308,6 +307,7 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
             self.running = toState == .running
         }
         
+        /// Save Wokrout, Route
         if toState == .ended {
             
             builder?.endCollection(withEnd: date) { (success, error) in

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -390,22 +390,22 @@ extension WorkoutManager: CLLocationManagerDelegate {
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         switch manager.authorizationStatus {
         case .notDetermined:
-            print("위치 권한 결정 안됨")
+            NSLog("위치 권한 결정 안됨")
             manager.requestWhenInUseAuthorization()
         case .restricted:
-            print("위치 권한 제한됨")
+            NSLog("위치 권한 제한됨")
             manager.requestAlwaysAuthorization()
         case .denied:
-            print("위치 권한 거부")
+            NSLog("위치 권한 거부")
             manager.requestAlwaysAuthorization()
         case .authorizedAlways:
-            print("위치 권한 항상 허용")
+            NSLog("위치 권한 항상 허용")
             startLocationUpdates()
         case .authorizedWhenInUse:
-            print("위치 권한 사용중 허용")
+            NSLog("위치 권한 사용중 허용")
             startLocationUpdates()
         @unknown default:
-            print(manager.authorizationStatus)
+            NSLog(manager.authorizationStatus.rawValue.description)
         }
     }
     

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -353,6 +353,7 @@ extension WorkoutManager: CLLocationManagerDelegate {
         
         // Filter the raw data.
         let filteredLocations = locations.filter { (location: CLLocation) -> Bool in
+            // 필터 조정치 필요, 예시 121, 66등으로 20 미만인 필터 데이터가 존재하지 않음
             location.horizontalAccuracy <= 20.0
         }
         

--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -362,6 +362,7 @@ extension WorkoutManager: HKLiveWorkoutBuilderDelegate {
     }
 }
 
+// MARK: - CLLocationManagerDelegate
 extension WorkoutManager: CLLocationManagerDelegate {
     // MARK: - 위치 정보가 수집되면 불리는 메서드
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/SoccerBeat/SoccerBeat-Watch-App-Info.plist
+++ b/SoccerBeat/SoccerBeat-Watch-App-Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>내 위치 확인을 위해 권한이 필요합니다. </string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>내 위치 확인을 위해 권한이 필요합니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSans-Black.ttf</string>

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -784,6 +784,8 @@
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "내 위치 확인을 위해 권한이 필요합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "내 위치 확인을 위해 권한이 필요합니다. ";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.SoccerBeat.GuryongpoIOS;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -821,6 +823,8 @@
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "내 위치 확인을 위해 권한이 필요합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "내 위치 확인을 위해 권한이 필요합니다. ";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.GuryongpoIOS.Guryongpo;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -776,7 +776,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SoccerBeat Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = V7Y2HCV8V2;
+				DEVELOPMENT_TEAM = D7F6ZDDCV9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SoccerBeat-Watch-App-Info.plist";
@@ -785,7 +785,7 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.SoccerBeat.Guryongpo;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.SoccerBeat.GuryongpoIOS;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -813,7 +813,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SoccerBeat Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = V7Y2HCV8V2;
+				DEVELOPMENT_TEAM = D7F6ZDDCV9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SoccerBeat-Watch-App-Info.plist";
@@ -822,7 +822,7 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "SoccerBeat의 경기 데이터 분석을 위해 사용됩니다.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.SoccerBeat.Guryongpo;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.GuryongpoIOS.Guryongpo;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -852,7 +852,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SoccerBeat/Preview Content\"";
-				DEVELOPMENT_TEAM = V7Y2HCV8V2;
+				DEVELOPMENT_TEAM = D7F6ZDDCV9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SoccerBeat/Info.plist;
@@ -870,7 +870,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeat.Guryongpo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeatGucci.Guryongpo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
@@ -891,7 +891,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SoccerBeat/Preview Content\"";
-				DEVELOPMENT_TEAM = V7Y2HCV8V2;
+				DEVELOPMENT_TEAM = D7F6ZDDCV9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SoccerBeat/Info.plist;
@@ -909,7 +909,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeat.Guryongpo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeatGucci.Guryongpo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## 🐲 관련 이슈

#114, 

## 🏃‍♂️ 구현/변경 사항
- [x] 코어로케이션 권한 획득 추가
- [x] 워치에서 현재 위치 읽어옴
- [x] 읽어 온 데이터가 저장됨

## 📷 스크린샷
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/c90af822-c851-43a2-9c7c-5f214fd971d0)

![Pasted Graphic](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/2beff64e-a71c-4617-9b24-d302f8f424de)

## 🙏To Reviewer
@yunwkgus 코드 변경 사항이 `WorkoutManager`에서 생깁니다. 
리뷰시에 유의하면서 리뷰해주시면 감사하겠습니다. 

### 세션 저장 과정에서 흐름에 대한 무지
세션이 어떻게 멈추고 Builder에서 어떻게 저장하는지는 알겠는데 다음의 흐름을 모르겠습니다. 

1. `WorkoutManager.endWorkout()`이 먼저 불리는지, `WorkoutManager.workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState,
                        from fromState: HKWorkoutSessionState, date: Date) `이 먼저 불리는지 순서 문제
2. `WorkoutManager.showingSummaryView`가 호출 되는 시점에 따라서 workoutSession에 영향이 가는지? 

이 부분이 해결이 안되서 저장이 안됩니다. 

---
# 11월 7일 추가 PR분 

## 작업내용
- [x] 읽어 온 데이터가 저장됨
- [x] `WorkoutManager.startWorkout()`이 두 번 호출되는 버그 수정

## 에러 발생의 이유
- `WorkoutManager.session`이 변화함에 따라서 `WorkoutManager.workoutSession`의 델리게이트 메서드가 작동을 해야하는데 어떠한 이유로 작동을 하지 않음
- 게임을 시작하든, 게임을 종료하든 session.running으로 동작함, (session.pause는 제대로 동작)
- 예상 동작은 "경기 종료" 버튼을 누르면 session.end 로 넘어갈 것을 기대했는데 이는 문제로 작용함
- 디버그 프린트를 찍으면서 디버그를 한 결과, 경기 종료 버튼을 누르면 WorkManager.startWorkout() 메서드가 중복해서 동작하는 것을 확인

## 버그 픽스 
1. `PrecountView`: 게임 시작 버튼을 누르면 나타나는 뷰인데, `startWorkout()`메서드를 `onDisapper()` 수정자에서 선언하고 있었음
2. 위 뷰를 `StartView`의 Body에서 if-else 문으로 선언하고 있는데, 문제는 경기 종료하면 StartView가 나타나 배경에 깔리고 그 위로 경기의 요약된 데이터를 덮어써서 보여주는 형식으로 보여주기 때문에 발생함. **다시 말해, 경기 종료시 `StartView-PrecountView`가 호출되는 것**
3. 결과적으로 1번에 언급한 `PrecountView`의 `onDisappear`가 호출되서 경기 종료시에도 `startWorkout()` 메서드가 호출됨
4. 따라서 새로운 세션이 생성되고 각종 빌더와 세션의 델리게이트가 새롭게 선언되어서 종료 메서드가 도달하지 않는 거였음
5. PrecountView가 사라질 때 호출하는 것이 아닌, count 의 값이 1이 될 때 startWorkout을 호출하도록 변경하였음

- 애플워치에서 종료 버튼을 누르는 화면
![일시정지, 종료](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/337b7cf7-0166-40f7-ba73-8386a281624f)

- 경기 종료 후 화면 전환시 밑바탕에 깔리는 `StartView`, 0~1초에서 넘어가는 화면에서 밑에 깔리는 파란원이 `StartView`

https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/25d26b2f-9634-4abb-84ed-ee24d1e94817


- `startWorkout()`이 두 번 불리는 에러
<img width="1108" alt="start 두번 불리는 에러" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/9457938a-1d96-4e4b-8c85-af18101d2960">

- `StartView`에서 if-else로 호출하는 `PrecountView`, 이 때문에 바로 disappear가 호출됨
<img width="761" alt="문제의 원인" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/4bdca13a-ebb3-43fa-9853-249f64951a9c">

- `PrecountView`에서 사용하던 수정자를 변경
<img width="536" alt="이거를 이용해서 해결함" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/86e95c24-05c5-4f5f-90ec-b7561bd09266">

- 해결되서 프린트문이 제대로 찍히는 모습
<img width="1259" alt="버그 해결해서 루트 저장되는 모습" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/2650a1b4-1319-4c60-80b4-e6f5eb1c7cce">
