### PR TITLE
feat: [#175] ProfileView layout 설정

### DIFF
--- a/SoccerBeat/Share/Utiles/FloatingCapsuleModifier.swift
+++ b/SoccerBeat/Share/Utiles/FloatingCapsuleModifier.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct FloatingCapsuleModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
+            .font(.custom("NotoSans-Regular", size: 14))
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .overlay {

--- a/SoccerBeat/SoccerBeat/UI/Screens/MyCardView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MyCardView.swift
@@ -41,24 +41,24 @@ struct MyCardView: View {
     var body: some View {
         ZStack {
             VStack {
-                HStack {
-                    VStack(alignment: .leading, spacing: 0.0) {
-                        Text("Hello, Isaac")
-                        Text("How you like")
-                        Text("that?")
-                    }
-                    .foregroundStyle(!isFlipped ?
-                        .linearGradient(colors: [.brightmint, .white], startPoint: .topLeading, endPoint: .bottomTrailing) : .linearGradient(colors: [.titlegray, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
-                    .font(.custom("SFProText-HeavyItalic", size: 36))
-                    .kerning(-1.5)
-                    .padding(.leading, 10.0)
-                    Spacer()
-                }
-                .padding(.top, 30)
-                .padding(.horizontal)
-                
-                Spacer()
-                    .frame(height: 80)
+//                HStack {
+//                    VStack(alignment: .leading, spacing: 0.0) {
+//                        Text("Hello, Isaac")
+//                        Text("How you like")
+//                        Text("that?")
+//                    }
+//                    .foregroundStyle(!isFlipped ?
+//                        .linearGradient(colors: [.brightmint, .white], startPoint: .topLeading, endPoint: .bottomTrailing) : .linearGradient(colors: [.titlegray, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
+//                    .font(.custom("SFProText-HeavyItalic", size: 36))
+//                    .kerning(-1.5)
+//                    .padding(.leading, 10.0)
+//                    Spacer()
+//                }
+//                .padding(.top, 30)
+//                .padding(.horizontal)
+//                
+//                Spacer()
+//                    .frame(height: 80)
                 ZStack {
                     CardFront(width: width, height: height, degree: $frontDegree, viewModel: viewModel)
                     CardBack(width: width, height: height, degree: $backDegree)

--- a/SoccerBeat/SoccerBeat/UI/Screens/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/ProfileView.swift
@@ -10,10 +10,42 @@ import SwiftUI
 struct ProfileView: View {
     @State var isFlipped: Bool = false
     @StateObject var viewModel = ProfileModel()
+    @State var userName: String = ""
     
     var body: some View {
-        VStack {
-            MyCardView(isFlipped: $isFlipped, viewModel: viewModel)
+        ScrollView {
+            VStack {
+                HStack {
+                    VStack(alignment: .leading, spacing: 0.0) {
+                        HStack(spacing: 0.0) {
+                            Text("Hello, ")
+                            TextField("Name", text: $userName)
+                                .onChange(of: userName) { _ in
+                                    UserDefaults.standard.set(userName, forKey: "userName")
+                                }
+                        }
+                        Text("How you like that?")
+                    }
+                    .foregroundStyle(!isFlipped ?
+                        .linearGradient(colors: [.brightmint, .white], startPoint: .topLeading, endPoint: .bottomTrailing) : .linearGradient(colors: [.titlegray, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .font(.custom("SFProText-HeavyItalic", size: 36))
+                    .kerning(-1.5)
+                    .padding(.leading, 10.0)
+                    Spacer()
+                }
+                .padding(.top, 30)
+                .padding(.horizontal)
+                
+                Spacer()
+                    .frame(height: 80)
+                
+                MyCardView(isFlipped: $isFlipped, viewModel: viewModel)
+                PhotoSelectButtonView(viewModel: viewModel)
+                    .opacity(isFlipped ? 1 : 0)
+                    .padding()
+            }
+        }.onAppear {
+            userName = UserDefaults.standard.string(forKey: "userName") ?? ""
         }
     }
 }

--- a/SoccerBeat/SoccerBeat/UI/Screens/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/ProfileView.swift
@@ -14,35 +14,74 @@ struct ProfileView: View {
     
     var body: some View {
         ScrollView {
-            VStack {
-                HStack {
-                    VStack(alignment: .leading, spacing: 0.0) {
-                        HStack(spacing: 0.0) {
-                            Text("Hello, ")
-                            TextField("Name", text: $userName)
-                                .onChange(of: userName) { _ in
-                                    UserDefaults.standard.set(userName, forKey: "userName")
-                                }
-                        }
-                        Text("How you like that?")
+            ZStack {
+                BackgroundImageView()
+                
+                VStack {
+                    HStack {
+                        Text("# 이번 경기 지표를 내 평균 능력치와 비교해 볼까요?")
+                            .floatingCapsuleStyle()
+                            .padding(.horizontal)
+                        
+                        Spacer()
                     }
-                    .foregroundStyle(!isFlipped ?
-                        .linearGradient(colors: [.brightmint, .white], startPoint: .topLeading, endPoint: .bottomTrailing) : .linearGradient(colors: [.titlegray, .white], startPoint: .topLeading, endPoint: .bottomTrailing))
-                    .font(.custom("SFProText-HeavyItalic", size: 36))
-                    .kerning(-1.5)
-                    .padding(.leading, 10.0)
+                    
+                    HStack {
+                        VStack(alignment: .leading, spacing: 0.0) {
+                            HStack(spacing: 0.0) {
+                                Text("Hello, ")
+                                TextField("Name", text: $userName)
+                                    .onChange(of: userName) { _ in
+                                        UserDefaults.standard.set(userName, forKey: "userName")
+                                    }
+                            }
+                            Text("How you like that?")
+                        }
+                        .font(.custom("SFProText-HeavyItalic", size: 36))
+                        .kerning(-1.5)
+                        .padding(.leading, 10.0)
+                        Spacer()
+                    }
+                    .padding(.top, 30)
+                    .padding(.horizontal)
+                    
                     Spacer()
+                        .frame(height: 80)
+                    
+                    MyCardView(isFlipped: $isFlipped, viewModel: viewModel)
+                    PhotoSelectButtonView(viewModel: viewModel)
+                        .opacity(isFlipped ? 1 : 0)
+                        .padding()
+                    
+                    let average = [3.0, 2.4, 3.4, 3.2, 2.8, 3.3]
+                    let recent = [4.1, 3.0, 3.5, 3.8, 3.5, 2.8]
+                    ViewControllerContainer(RadarViewController(radarAverageValue: average, radarAtypicalValue: recent))
+                        .fixedSize()
+                        .frame(width: 210, height: 210)
+                    
+                    Spacer().frame(height: 100)
+                    
+                    HStack {
+                        Text("# 이번 경기 지표를 내 평균 능력치와 비교해 볼까요?")
+                            .floatingCapsuleStyle()
+                            .padding(.horizontal)
+                        
+                        Spacer()
+                    }
+                    
+                    HStack {
+                        VStack(alignment: .leading, spacing: 0.0) {
+                            Text("My")
+                            Text("Card Collection")
+                        }
+                        .font(.custom("SFProText-HeavyItalic", size: 36))
+                        .kerning(-1.5)
+                        .padding(.leading, 10.0)
+                        Spacer()
+                    }
+                    .padding(.top, 30)
+                    .padding(.horizontal)
                 }
-                .padding(.top, 30)
-                .padding(.horizontal)
-                
-                Spacer()
-                    .frame(height: 80)
-                
-                MyCardView(isFlipped: $isFlipped, viewModel: viewModel)
-                PhotoSelectButtonView(viewModel: viewModel)
-                    .opacity(isFlipped ? 1 : 0)
-                    .padding()
             }
         }.onAppear {
             userName = UserDefaults.standard.string(forKey: "userName") ?? ""


### PR DESCRIPTION
## 🐲 관련 이슈
- #175 

## 🏃‍♂️ 구현/변경 사항
- 이름을 입력받아 UserDefaults에 저장.
- 사용자의 능력치 스파이더 차트로 구현.
- FloatingCapsuleModifier 폰트 설정.

## 📷 스크린샷
![Simulator Screenshot - iPhone 15 Pro - 2023-11-20 at 05 08 19](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/77256855/cff6306e-d89c-4fd9-9e2f-bf913f756815)

## ✏️  ETC
- 사용자 프로필은 헨리에게 부탁드릴게요..

## 🙏To Reviewer