### PR TITLE
feat: [#235] 워치 단위 에러 수정 및 스프린트 속도 20km/h -> 15km/h 조정

### DIFF
--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/WatchWorkoutManager.swift
@@ -58,7 +58,8 @@ class WorkoutManager: NSObject, ObservableObject {
     
     var energy: Double = 0
     
-    let sprintSpeed: Double = 5.5556 // modify it to test code
+//    let sprintSpeed: Double = 5.5556 // modify it to test code
+    let sprintSpeed: Double = 4.16 // 4.16ms == 15km/h
     
     @Published var isSprint: Bool = false
     var maxSpeed: Double = 0.0
@@ -339,12 +340,12 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
                     
                     // custom data 를 routedata의 metadata에 저장
                     let metadata: [String: Any] = [
-                        "MaxSpeed": Double(Int(self!.maxSpeed * 100.rounded()))/100,
+                        "MaxSpeed": (self!.maxSpeed * 3.6).rounded(at: 2) , // km/h
                         "SprintCount": self!.sprint,
                         "MinHeartRate": self!.saveMinHeartRate,
                         "MaxHeartRate": self!.saveMaxHeartRate,
-                        "Distance": (Double(Int(self!.distance/1000 * 100 ))) / 100,
-                        "Acceleration": Double(Int(self!.acceleration * 100.rounded()))/100
+                        "Distance": (self!.distance / 1000).rounded(at: 1), // km
+                        "Acceleration": self!.acceleration.rounded(at: 2) // m/s^2
                     ]
                     
                     self?.routeBuilder?.finishRoute(with: workout, metadata: metadata) { (newRoute, _) in

--- a/SoccerBeat/SoccerBeat/Interactors/HealthInteractor.swift
+++ b/SoccerBeat/SoccerBeat/Interactors/HealthInteractor.swift
@@ -124,8 +124,8 @@ class HealthInteractor: ObservableObject {
                                                 time: time as! String,
                                                 distance: custom["Distance", default: 0.0] as! Double,
                                                 sprint: custom["SprintCount", default: 0] as! Int,
-                                                velocity: custom["MaxSpeed", default: 0.0] as! Double,
-                                                acceleration: custom["Acceleration", default: 0.0] as! Double,
+                                                velocity: custom["MaxSpeed", default: 0.0] as! Double, // km/h
+                                                acceleration: custom["Acceleration", default: 0.0] as! Double, // m/s^2
                                                 heartRate: ["max": custom["MaxHeartRate", default: 0] as! Int,
                                                             "min": custom["MinHeartRate", default: 0] as! Int],
                                                 route: routes,

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchDetailView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchDetailView.swift
@@ -296,7 +296,7 @@ struct FieldRecordDataView: View {
                         Text("최소 심박수")
                             .font(.fieldRecordTitle)
                         HStack(alignment: .bottom, spacing: 0) {
-                            Text(workoutData.maxHeartRate.formatted())
+                            Text(workoutData.minHeartRate.formatted())
                                 .font(.fieldRecordMeasure)
                             Text(" Bpm")
                                 .font(.fieldRecordUnit)


### PR DESCRIPTION
## 🐲 관련 이슈
close #235 

## 🏃‍♂️ 구현/변경 사항
- 워치 단위 에러 수정
- min bpm 수정
- 스프린트 속도 15km/h 하향 조정

## 📷 스크린샷


## ✏️  ETC
- 워치 workoutmanager 기본으로 저장된 단위들은 m/s 기준입니다. 워치에서 요약을 볼 때에 m/s * 3.6 으로 변환해서 km/h 로 표현합니다.
- workout manager 에서 메타데이터를 넘길 때 최고 속도는 km/h, 가속도는 m/s^2 로 아예 단위 변환을 한 뒤에 숫자를 넘겼습니다.
- health interactor 에서는 그대로 사용하면 됩니다.

## 🙏To Reviewer
