### PR TITLE
fix: [#238] 추세 그래프에서 같은 날 여러 데이터 있을 시 변환

### DIFF
--- a/SoccerBeat/SoccerBeat/Interactors/HealthInteractor.swift
+++ b/SoccerBeat/SoccerBeat/Interactors/HealthInteractor.swift
@@ -52,7 +52,7 @@ class HealthInteractor: ObservableObject {
     
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         return formatter
     }()
     

--- a/SoccerBeat/SoccerBeat/Photos/Profile.swift
+++ b/SoccerBeat/SoccerBeat/Photos/Profile.swift
@@ -18,6 +18,7 @@ struct Profile: View {
             if self.image != nil {
                 Image(uiImage: self.image!)
                     .resizable()
+                    .scaledToFill()
                     .frame(width: width, height: height)
                     .mask {
                         Image("MaskLayer")

--- a/SoccerBeat/SoccerBeat/Resources/WorkoutData.swift
+++ b/SoccerBeat/SoccerBeat/Resources/WorkoutData.swift
@@ -30,15 +30,20 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
     }
   
     var matchBadge: [Int]
-    var monthDay: String {
-        Array(date.split(separator: "."))[1...2].joined(separator: ".")
-    }
+
     var day: Int {
-        Int(date.split(separator: ".")[2]) ?? 0
+        let beforeT = String(date.split(separator: "T")[0])
+        let splited = beforeT.split(separator: "-")[2]
+        return Int(splited) ?? 0
+    }
+    var yearMonthDay: String {
+        let beforeT = String(date.split(separator: "T")[0])
+        let rawValueOfYearMonthDay = beforeT.split(separator: "-").joined(separator: ".")
+        return String(rawValueOfYearMonthDay)
     }
     
     static let example = Self(dataID: 0,
-                              date: "2023.10.15",
+                              date: "2023-10-09T01:20:32Z",
                               time: "34:43",
                               distance: 4.5,
                               sprint: 6,
@@ -50,7 +55,7 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
                               matchBadge: [-1, 2, 0])
     
     static let blankExample = Self(dataID: 0,
-                                   date: "2023.10.15",
+                                   date: "2023-10-09T01:20:32Z",
                                    time: "34:43",
                                    distance: 0.1,
                                    sprint: 1,
@@ -60,11 +65,8 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
                                    route: [],
                                    center: [37.58647414212885, 126.9748537678651], matchBadge: [0, 0, 0])
     
-    private let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "Ko-kr")
-        formatter.dateFormat = "yyyy.MM.dd"
-        return formatter
+    private let dateFormatter: ISO8601DateFormatter = {
+        return ISO8601DateFormatter()
     }()
 }
 
@@ -123,15 +125,15 @@ extension WorkoutData {
 }
 
 let fakeWorkoutData: [WorkoutData] = [
-    WorkoutData(dataID: 1, date: "2023.10.09", time: "61:10", distance: 3.5, sprint: 3, velocity: 10.5, acceleration: 3.0, heartRate: ["max": 171, "min": 53], route: [], center: [0, 0], matchBadge: [0,3,2]),
-    WorkoutData(dataID: 2, date: "2023.10.10", time: "62:10", distance: 2.1, sprint: 5, velocity: 11.5, acceleration: 3.0, heartRate: ["max": 152, "min": 70], route: [], center: [0, 0], matchBadge: [0,1,3]),
-    WorkoutData(dataID: 3, date: "2023.10.11", time: "60:10", distance: 1.1, sprint: 7, velocity: 8.5, acceleration: 3.0, heartRate: ["max": 167, "min": 92], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-    WorkoutData(dataID: 4, date: "2023.10.12", time: "60:10", distance: 5.1, sprint: 9, velocity: 12.5, acceleration: 3.0, heartRate: ["max": 185, "min": 100], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-    WorkoutData(dataID: 5, date: "2023.10.13", time: "60:10", distance: 4.5, sprint: 11, velocity: 17.2, acceleration: 3.0, heartRate: ["max": 175, "min": 60], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-    WorkoutData(dataID: 6, date: "2023.10.14", time: "60:10", distance: 3.6, sprint: 5, velocity: 24.4, acceleration: 3.0, heartRate: ["max": 190, "min": 79], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-    WorkoutData(dataID: 7, date: "2023.10.15", time: "60:10", distance: 3.8, sprint: 13, velocity: 15.9, acceleration: 3.0, heartRate: ["max": 183, "min": 91], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-    WorkoutData(dataID: 8, date: "2023.10.16", time: "60:10", distance: 2.9, sprint: 17, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 169, "min": 79], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-    WorkoutData(dataID: 9, date: "2023.10.17", time: "60:10", distance: 5.3, sprint: 12, velocity: 23.5, acceleration: 3.0, heartRate: ["max": 187, "min": 60], route: [], center: [0, 0], matchBadge: [-1,2,0])
+    WorkoutData(dataID: 1, date: "2023-10-09T01:20:32Z", time: "61:10", distance: 3.5, sprint: 3, velocity: 10.5, acceleration: 3.0, heartRate: ["max": 171, "min": 53], route: [], center: [0, 0], matchBadge: [0,3,2]),
+    WorkoutData(dataID: 2, date: "2023-10-09T01:20:35Z", time: "62:10", distance: 2.1, sprint: 5, velocity: 11.5, acceleration: 3.0, heartRate: ["max": 152, "min": 70], route: [], center: [0, 0], matchBadge: [0,1,3]),
+    WorkoutData(dataID: 3, date: "2023-10-09T01:20:38Z", time: "60:10", distance: 1.1, sprint: 7, velocity: 8.5, acceleration: 3.0, heartRate: ["max": 167, "min": 92], route: [], center: [0, 0], matchBadge: [-1,2,0]),
+    WorkoutData(dataID: 4, date: "2023-10-19T01:20:32Z", time: "60:10", distance: 5.1, sprint: 9, velocity: 12.5, acceleration: 3.0, heartRate: ["max": 185, "min": 100], route: [], center: [0, 0], matchBadge: [-1,2,0]),
+    WorkoutData(dataID: 5, date: "2023-10-20T01:20:32Z", time: "60:10", distance: 4.5, sprint: 11, velocity: 17.2, acceleration: 3.0, heartRate: ["max": 175, "min": 60], route: [], center: [0, 0], matchBadge: [-1,2,0]),
+    WorkoutData(dataID: 6, date: "2023-10-21T01:20:32Z", time: "60:10", distance: 3.6, sprint: 5, velocity: 24.4, acceleration: 3.0, heartRate: ["max": 190, "min": 79], route: [], center: [0, 0], matchBadge: [-1,2,0]),
+    WorkoutData(dataID: 7, date: "2023-10-23T01:20:32Z", time: "60:10", distance: 3.8, sprint: 13, velocity: 15.9, acceleration: 3.0, heartRate: ["max": 183, "min": 91], route: [], center: [0, 0], matchBadge: [-1,2,0]),
+    WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.9, sprint: 17, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 169, "min": 79], route: [], center: [0, 0], matchBadge: [-1,2,0]),
+    WorkoutData(dataID: 9, date: "2023-10-27T01:20:32Z", time: "60:10", distance: 5.3, sprint: 12, velocity: 23.5, acceleration: 3.0, heartRate: ["max": 187, "min": 60], route: [], center: [0, 0], matchBadge: [-1,2,0])
 ]
 
 let fakeAverageData: WorkoutAverageData = WorkoutAverageData(maxHeartRate: 180,

--- a/SoccerBeat/SoccerBeat/UI/Charts/BPMChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/BPMChart.swift
@@ -11,10 +11,10 @@ import Charts
 struct BPMChartView: View {
     let workouts: [WorkoutData]
     private var startDate: String {
-        workouts.first?.date ?? "2023.10.10"
+        workouts.first?.yearMonthDay ?? "2023.10.10"
     }
     private var endDate: String {
-        workouts.last?.date ?? "2023.10.10"
+        workouts.last?.yearMonthDay ?? "2023.10.10"
     }
     var body: some View {
         let fastest = maximum(of: workouts)

--- a/SoccerBeat/SoccerBeat/UI/Charts/DistanceChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/DistanceChart.swift
@@ -11,10 +11,10 @@ import Charts
 struct DistanceChartView: View {
     let workouts: [WorkoutData]
     private var startDate: String {
-        workouts.first?.date ?? "2023.10.10"
+        workouts.first?.yearMonthDay ?? "2023.10.10"
     }
     private var endDate: String {
-        workouts.last?.date ?? "2023.10.10"
+        workouts.last?.yearMonthDay ?? "2023.10.10"
     }
     var body: some View {
         let fastest = maximum(of: workouts)

--- a/SoccerBeat/SoccerBeat/UI/Charts/SpeedChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/SpeedChart.swift
@@ -11,10 +11,10 @@ import Charts
 struct SpeedChartView: View {
     let workouts: [WorkoutData]
     private var startDate: String {
-        workouts.first?.date ?? "2023.10.10"
+        workouts.first?.yearMonthDay ?? "2023.10.10"
     }
     private var endDate: String {
-        workouts.last?.date ?? "2023.10.10"
+        workouts.last?.yearMonthDay ?? "2023.10.10"
     }
     var body: some View {
         let fastest = maximum(of: workouts)
@@ -178,7 +178,7 @@ extension SpeedChartView {
                         .font(.averageText)
                         .foregroundStyle(.averageTextStyle)
                     Group {
-                        Text(average(of: workouts).rounded(), format: .number)
+                        Text(average(of: workouts).rounded(at: 1))
                         + Text(" km/h")
                     }
                     .font(.averageValue)

--- a/SoccerBeat/SoccerBeat/UI/Charts/SprintChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/SprintChart.swift
@@ -11,10 +11,10 @@ import Charts
 struct SprintChartView: View {
     let workouts: [WorkoutData]
     private var startDate: String {
-        workouts.first?.date ?? "2023.10.10"
+        workouts.first?.yearMonthDay ?? "2023.10.10"
     }
     private var endDate: String {
-        workouts.last?.date ?? "2023.10.10"
+        workouts.last?.yearMonthDay ?? "2023.10.10"
     }
     var body: some View {
         let fastest = maximum(of: workouts)
@@ -178,7 +178,7 @@ extension SprintChartView {
                         .font(.averageText)
                         .foregroundStyle(.averageTextStyle)
                     Group {
-                        Text(average(of: workouts).rounded())
+                        Text(average(of: workouts).rounded(at: 0))
                         + Text(" 회")
                     }
                     .font(.averageValue)

--- a/SoccerBeat/SoccerBeat/UI/InformationButton.swift
+++ b/SoccerBeat/SoccerBeat/UI/InformationButton.swift
@@ -15,6 +15,7 @@ struct InformationButton: View {
             isInfoOpen.toggle()
         } label: {
             HStack(spacing: 0) {
+                Text(" ")
                 Image(.infoIcon)
                     .resizable()
                     .frame(width: 11, height: 15)
@@ -22,6 +23,7 @@ struct InformationButton: View {
                     Text(" \(message)")
                         .foregroundStyle(.white)
                 }
+                Text(" ")
             }
             .floatingCapsuleStyle(color: isInfoOpen ? .floatingCapsuleGray : .white.opacity(0.8))
         }

--- a/SoccerBeat/SoccerBeat/UI/Screens/MainView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MainView.swift
@@ -45,7 +45,7 @@ struct MainView: View {
                     
                     HStack(alignment: .bottom) {
                         VStack(alignment: .leading) {
-                            Text(userWorkouts[0].date)
+                            Text(userWorkouts[0].yearMonthDay)
                                 .font(.mainSubTitleText)
                                 .opacity(0.7)
                             Text("최근 경기")

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchRecapView.swift
@@ -144,7 +144,7 @@ struct MatchListItemView: View {
  
                 VStack(alignment: .leading) {
                     Group {
-                        Text(workoutData.date.description + " - " + currentLocation)
+                        Text(workoutData.yearMonthDay.description + " - " + currentLocation)
                             .task {
                                 currentLocation = await workoutData.location
                             }


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #238 

## 🏃‍♂️ 구현/변경 사항
- 추세 그래프 같은 날에 여러 경기가 있을 시 시간 순서로 정렬
- 프로필 사진 정렬 흐뜨러지는 것 수정
- InfoButton 움직이는 듯한 버그 수정

## 📷 스크린샷

- 그전에는 앞에 9일 3개가 뭉쳐져서 나와있었어요.
<img width="245" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/c61db786-8172-40e2-a611-11f6db2cf785">

- 프로필 안 짜부(?)됩니다.
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/2bbe59c5-ff20-468c-b7d6-d3409f637f23)

- InformationButton 눌러도 흔들림 없음

https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/f42b820e-f289-49b4-848d-0bd933e3c183



## ✏️  ETC


## 🙏To Reviewer
