### PR TITLE
refactor:[#268] 레이더 차트, WorkoutAverageData를 사용하는 뷰 재구성

### DIFF
--- a/SoccerBeat/SoccerBeat Watch App/WorkoutManager/MatricsIndicator.swift
+++ b/SoccerBeat/SoccerBeat Watch App/WorkoutManager/MatricsIndicator.swift
@@ -132,7 +132,6 @@ final class MatricsIndicator: NSObject, ObservableObject {
         self.zone5Count = 0
     }
     
-    
     func updateForStatistics(_ statistics: HKStatistics?) {
         guard let statistics = statistics else { return }
         DispatchQueue.main.async {

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		BEA63A662B0AFDFF000A309D /* ActivityEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA63A652B0AFDFF000A309D /* ActivityEnum.swift */; };
 		BEA63A672B0AFDFF000A309D /* ActivityEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA63A652B0AFDFF000A309D /* ActivityEnum.swift */; };
 		BEA63A6A2B0B386C000A309D /* AnalyticsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA63A692B0B386C000A309D /* AnalyticsComponent.swift */; };
+		BEB1D21D2BB01AE9007B2846 /* RadarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB1D21C2BB01AE9007B2846 /* RadarChartView.swift */; };
 		BEB666C22AE4E16D0090195A /* StartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB666C12AE4E16D0090195A /* StartView.swift */; };
 		BEC1E5CE2AE6A254008B285E /* ElapsedTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC1E5CD2AE6A254008B285E /* ElapsedTimeView.swift */; };
 		BECCFAB22B0665D2009F4BE5 /* SpeedChartOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECCFAB12B0665D2009F4BE5 /* SpeedChartOverview.swift */; };
@@ -227,6 +228,7 @@
 		BEA63A602B0AF608000A309D /* HighlightModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightModifier.swift; sourceTree = "<group>"; };
 		BEA63A652B0AFDFF000A309D /* ActivityEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEnum.swift; sourceTree = "<group>"; };
 		BEA63A692B0B386C000A309D /* AnalyticsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsComponent.swift; sourceTree = "<group>"; };
+		BEB1D21C2BB01AE9007B2846 /* RadarChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarChartView.swift; sourceTree = "<group>"; };
 		BEB666C12AE4E16D0090195A /* StartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartView.swift; sourceTree = "<group>"; };
 		BEC1E5CD2AE6A254008B285E /* ElapsedTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeView.swift; sourceTree = "<group>"; };
 		BEC1E5CF2AE6B4AF008B285E /* SoccerBeat-Watch-App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "SoccerBeat-Watch-App-Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -373,6 +375,7 @@
 				D3A1F1102B06847600EB2049 /* ProfileView.swift */,
 				FBCED9312AE4218E00C57BF9 /* MatchRecapView.swift */,
 				FBCED9342AE4A83900C57BF9 /* MatchDetailView.swift */,
+				BEB1D21C2BB01AE9007B2846 /* RadarChartView.swift */,
 				FBCED91F2AE3D38900C57BF9 /* MyCardView.swift */,
 				FBA3DA612B00E6EF0025AD7B /* ShareView.swift */,
 				682D64882AFDBF8C00D7F07B /* PhotoSelectButtonView.swift */,
@@ -797,6 +800,7 @@
 			files = (
 				BEA63A612B0AF608000A309D /* HighlightModifier.swift in Sources */,
 				BECCFAB42B06698F009F4BE5 /* DistanceChartOverview.swift in Sources */,
+				BEB1D21D2BB01AE9007B2846 /* RadarChartView.swift in Sources */,
 				FB2EC9C32B0B50BB0050B0E8 /* BadgeImageDictionary.swift in Sources */,
 				BE93F1912B00937000C33756 /* TextBorder+extension.swift in Sources */,
 				BE4A91562B011A46004AAFA3 /* BPMChart.swift in Sources */,

--- a/SoccerBeat/SoccerBeat/Photos/Profile.swift
+++ b/SoccerBeat/SoccerBeat/Photos/Profile.swift
@@ -9,7 +9,7 @@ import PhotosUI
 import SwiftUI
 
 struct Profile: View {
-    @ObservedObject var viewModel: ProfileModel
+    @EnvironmentObject var viewModel: ProfileModel
     @AppStorage("userImage") var userImage: Data = .init()
     let width : CGFloat
     let height : CGFloat
@@ -33,8 +33,7 @@ struct Profile: View {
                     }
             } else {
                 // TODO: - 로직 흐름에서 여기가 불릴 일이 없는 것 같습니다.
-                EditableCircularProfileImage(viewModel: viewModel,
-                                             width: width,
+                EditableCircularProfileImage(width: width,
                                              height: height)
                     .mask {
                         Image(.maskLayer)

--- a/SoccerBeat/SoccerBeat/Photos/ProfileImage.swift
+++ b/SoccerBeat/SoccerBeat/Photos/ProfileImage.swift
@@ -32,7 +32,7 @@ struct ProfileImage: View {
 
 // Transmit Profile ViewModel
 struct EditableCircularProfileImage: View {
-    @ObservedObject var viewModel: ProfileModel
+    @EnvironmentObject var viewModel: ProfileModel
     let width : CGFloat
     let height : CGFloat
     var body: some View {

--- a/SoccerBeat/SoccerBeat/Photos/ProfileModel.swift
+++ b/SoccerBeat/SoccerBeat/Photos/ProfileModel.swift
@@ -6,14 +6,118 @@
 //
 
 import CoreTransferable
+import Combine
 import PhotosUI
 import SwiftUI
 
 @MainActor
-class ProfileModel: ObservableObject {
+final class ProfileModel: ObservableObject {
+
+    let healthInteractor: HealthInteractor
+    @Published var averageAbility = WorkoutAverageData()
+    @Published var maxAbility = WorkoutAverageData()
+    @Published var allBadges: [[Bool]] = [[false, false, false, false],
+                                          [false, false, false, false],
+                                          [false, false, false, false]]
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(healthInteractor: HealthInteractor) {
+        self.healthInteractor = healthInteractor
+        binding()
+    }
+    
+    private func binding() {
+        healthInteractor.fetchWorkoutsSuccess.sink { workouts in
+            self.calculateAverageAbility(workouts)
+            self.caculateMaxAbility(workouts)
+            self.calculateBadge(workouts)
+        }
+        .store(in: &cancellables)
+    }
+    
+    func calculateBadge(_ workouts: [WorkoutData]) {
+        for workout in workouts {
+            if workout.distance < 0.2 {
+            } else if (0.2 <= workout.distance && workout.distance < 0.4) {
+                allBadges[0][0] = true
+            } else if (0.4 <= workout.distance && workout.distance < 0.6) {
+                allBadges[0][1] = true
+            } else if (0.6 <= workout.distance && workout.distance < 0.8) {
+                allBadges[0][2] = true
+            } else {
+                allBadges[0][3] = true
+            }
+            
+            if workout.sprint < 1 {
+            } else if (1 <= workout.sprint && workout.sprint < 2) {
+                
+                allBadges[1][0] = true
+            } else if (2 <= workout.sprint && workout.sprint < 3) {
+                
+                allBadges[1][1] = true
+            } else if (3 <= workout.sprint && workout.sprint < 4) {
+                
+                allBadges[1][2] = true
+            } else {
+                allBadges[1][3] = true
+            }
+            
+            if workout.velocity < 10 {
+                1
+            } else if (10 <= workout.velocity && workout.velocity < 15) {
+                
+                allBadges[2][0] = true
+            } else if (15 <= workout.velocity && workout.velocity < 20) {
+                
+                allBadges[2][1] = true
+            } else if (20 <= workout.velocity && workout.velocity < 25) {
+                
+                allBadges[2][2] = true
+            } else {
+                allBadges[2][3] = true
+            }
+        }
+    }
+    
+    private func caculateMaxAbility(_ workouts: [WorkoutData]) {
+        for workout in workouts {
+            maxAbility.maxHeartRate = max(maxAbility.maxHeartRate, workout.maxHeartRate)
+            maxAbility.minHeartRate = min(maxAbility.minHeartRate, workout.minHeartRate)
+            maxAbility.rangeHeartRate = max(maxAbility.rangeHeartRate, workout.maxHeartRate - workout.minHeartRate)
+            maxAbility.totalDistance = max(maxAbility.totalDistance, workout.distance)
+            maxAbility.maxAcceleration = max(maxAbility.maxAcceleration, workout.acceleration)
+            maxAbility.maxVelocity = max(maxAbility.maxVelocity, workout.velocity)
+            maxAbility.sprintCount = max(maxAbility.sprintCount, workout.sprint)
+            maxAbility.totalMatchTime = max(maxAbility.totalMatchTime, workout.playtimeSec)
+        }
+    }
+    
+    private func calculateAverageAbility(_ workouts: [WorkoutData]) {
+        for workout in workouts {
+            averageAbility.maxHeartRate += workout.maxHeartRate
+            averageAbility.minHeartRate += workout.minHeartRate
+            averageAbility.rangeHeartRate += workout.maxHeartRate - workout.minHeartRate
+            averageAbility.totalDistance += workout.distance
+            averageAbility.maxAcceleration += workout.acceleration
+            averageAbility.maxVelocity += workout.velocity
+            averageAbility.sprintCount += workout.sprint
+            averageAbility.totalMatchTime += workout.playtimeSec
+        }
+        
+        // Calculating average value..
+        let workoutCount = workouts.count
+        averageAbility.maxHeartRate /= workoutCount
+        averageAbility.minHeartRate /= workoutCount
+        averageAbility.rangeHeartRate /= workoutCount
+        averageAbility.totalDistance /= Double(workoutCount)
+        averageAbility.maxAcceleration /= Double(workoutCount)
+        averageAbility.maxVelocity /= Double(workoutCount)
+        averageAbility.sprintCount /= workoutCount
+        averageAbility.totalMatchTime /= workoutCount
+    }
     
     // MARK: - Profile Image
-    
     enum ImageState {
         case empty
         case loading(Progress)

--- a/SoccerBeat/SoccerBeat/Resources/DataConverter.swift
+++ b/SoccerBeat/SoccerBeat/Resources/DataConverter.swift
@@ -9,7 +9,14 @@ import Foundation
 
 final class DataConverter {
     // TODO: - 매개 변수가 4개가 넘어가면 별도의 타입을 고려
-    static func dataConverter(totalDistance: Double, maxHeartRate: Int, maxVelocity: Double, maxAcceleration: Double, sprintCount: Int, minHeartRate: Int, rangeHeartRate: Int, totalMatchTime: Int) -> [String: Double] {
+    static private func toLevelDictionary(totalDistance: Double,
+                                      maxHeartRate: Int,
+                                      maxVelocity: Double,
+                                      maxAcceleration: Double,
+                                      sprintCount: Int,
+                                      minHeartRate: Int,
+                                      rangeHeartRate: Int,
+                                      totalMatchTime: Int) -> [String: Double] {
         var levels: [String: Double] = [:]
         
         if totalDistance <= 1.0 {
@@ -109,5 +116,42 @@ final class DataConverter {
         }
         
         return levels
+    }
+    
+    static func toLevels(_ workout: WorkoutData) -> [Double] {
+        let recentLevel = toLevelDictionary(totalDistance: workout.distance,
+                                       maxHeartRate: workout.maxHeartRate,
+                                       maxVelocity: workout.velocity,
+                                       maxAcceleration: workout.acceleration,
+                                       sprintCount: workout.sprint,
+                                       minHeartRate: workout.minHeartRate,
+                                       rangeHeartRate: workout.maxHeartRate-workout.minHeartRate,
+                                       totalMatchTime: workout.playtimeSec)
+        
+        
+        return toTriple(recentLevel)
+    }
+    
+    static func toLevels(_ averageWorkout: WorkoutAverageData) -> [Double] {
+        let averageLevel = toLevelDictionary(totalDistance: averageWorkout.totalDistance,
+                                             maxHeartRate: averageWorkout.maxHeartRate,
+                                             maxVelocity: averageWorkout.maxVelocity,
+                                             maxAcceleration: averageWorkout.maxAcceleration,
+                                             sprintCount: averageWorkout.sprintCount,
+                                             minHeartRate: averageWorkout.minHeartRate,
+                                             rangeHeartRate: averageWorkout.maxHeartRate-averageWorkout.minHeartRate,
+                                             totalMatchTime: averageWorkout.totalMatchTime)
+        return toTriple(averageLevel)
+    }
+    
+    static private func toTriple(_ level: [String: Double]) -> [Double] {
+        return [
+            (level["totalDistance"] ?? 1.0) * 0.15 + (level["maxHeartRate"] ?? 1.0) * 0.35,
+            (level["maxVelocity"] ?? 1.0) * 0.3 + (level["maxAcceleration"] ?? 1.0) * 0.2,
+            (level["maxVelocity"] ?? 1.0) * 0.25 + (level["sprintCount"] ?? 1.0) * 0.125 + (level["maxHeartRate"] ?? 1.0) * 0.125,
+            (level["maxAcceleration"] ?? 1.0) * 0.4 + (level["minHeartRate"] ?? 1.0) * 0.1,
+            (level["totalDistance"] ?? 1.0) * 0.15 + (level["rangeHeartRate"] ?? 1.0) * 0.15 + (level["totalMatchTime"] ?? 1.0) * 0.2,
+            (level["totalDistance"] ?? 1.0) * 0.3 + (level["sprintCount"] ?? 1.0) * 0.1 + (level["maxHeartRate"] ?? 1.0) * 0.1
+        ]
     }
 }

--- a/SoccerBeat/SoccerBeat/Resources/WorkoutData.swift
+++ b/SoccerBeat/SoccerBeat/Resources/WorkoutData.swift
@@ -30,7 +30,46 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
         heartRate["min", default: 50] // Minimum heart rate during the match.
     }
     
-    var matchBadge: [Int]
+    var matchBadge: [Int] {
+        var badge = [0,0,0]
+
+        if distance < 0.2 {
+            badge[0] = -1
+        } else if (0.2 <= distance && distance < 0.4) {
+            badge[0] = 0
+        } else if (0.4 <= distance && distance < 0.6) {
+            badge[0] = 1
+        } else if (0.6 <= distance && distance < 0.8) {
+            badge[0] = 2
+        } else {
+            badge[0] = 3
+        }
+
+        if sprint < 1 {
+            badge[1] = -1
+        } else if (1 <= sprint && sprint < 2) {
+            badge[1] = 0
+        } else if (2 <= sprint && sprint < 3) {
+            badge[1] = 1
+        } else if (3 <= sprint && sprint < 4) {
+            badge[1] = 2
+        } else {
+            badge[1] = 3
+        }
+
+        if velocity < 10 {
+        } else if (10 <= velocity && velocity < 15) {
+            badge[2] = 0
+        } else if (15 <= velocity && velocity < 20) {
+            badge[2] = 1
+        } else if (20 <= velocity && velocity < 25) {
+            badge[2] = 2
+        } else {
+            badge[2] = 3
+        }
+
+        return badge
+    }
     
     var day: Int {
         let beforeT = String(date.split(separator: "T")[0])
@@ -43,6 +82,13 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
         return String(rawValueOfYearMonthDay)
     }
     
+    var playtimeSec: Int {
+        let separatedTime = time.components(separatedBy: ":")
+        let separatedMinutes = separatedTime[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        let separatedSeconds = separatedTime[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (Int(separatedMinutes) ?? 0) * 60 + (Int(separatedSeconds) ?? 0)
+    }
+    
     static let example = Self(dataID: 0,
                               date: "2023-10-09T01:20:32Z",
                               time: "34:43",
@@ -52,8 +98,7 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
                               acceleration: 3.0,
                               heartRate: ["max": 190, "min": 70],
                               route: [],
-                              center: [37.58647414212885, 126.9748537678651],
-                              matchBadge: [-1, 2, 0])
+                              center: [37.58647414212885, 126.9748537678651])
     
     static let blankExample = Self(dataID: 0,
                                    date: "2023-10-09T01:20:32Z",
@@ -64,18 +109,19 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
                                    acceleration: 1.0,
                                    heartRate: ["max": 80, "min": 60],
                                    route: [],
-                                   center: [37.58647414212885, 126.9748537678651], matchBadge: [0, 0, 0])
+                                   center: [37.58647414212885, 126.9748537678651])
     
+    // TODO: - Factory Method Pattern으로 빼내는건 어떨까요?
     static let exampleWorkouts = [
-        WorkoutData(dataID: 1, date: "2023-10-09T01:20:32Z", time: "61:10", distance: 3.5, sprint: 3, velocity: 10.5, acceleration: 3.0, heartRate: ["max": 171, "min": 53], route: [], center: [0, 0], matchBadge: [0,3,2]),
-        WorkoutData(dataID: 2, date: "2023-10-09T01:20:35Z", time: "62:10", distance: 2.1, sprint: 5, velocity: 11.5, acceleration: 3.0, heartRate: ["max": 152, "min": 70], route: [], center: [0, 0], matchBadge: [0,1,3]),
-        WorkoutData(dataID: 3, date: "2023-10-09T01:20:38Z", time: "60:10", distance: 1.1, sprint: 7, velocity: 8.5, acceleration: 3.0, heartRate: ["max": 167, "min": 92], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-        WorkoutData(dataID: 4, date: "2023-10-19T01:20:32Z", time: "60:10", distance: 5.1, sprint: 9, velocity: 12.5, acceleration: 3.0, heartRate: ["max": 185, "min": 100], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-        WorkoutData(dataID: 5, date: "2023-10-20T01:20:32Z", time: "60:10", distance: 4.5, sprint: 11, velocity: 17.2, acceleration: 3.0, heartRate: ["max": 175, "min": 60], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-        WorkoutData(dataID: 6, date: "2023-10-21T01:20:32Z", time: "60:10", distance: 3.6, sprint: 5, velocity: 24.4, acceleration: 3.0, heartRate: ["max": 190, "min": 79], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-        WorkoutData(dataID: 7, date: "2023-10-23T01:20:32Z", time: "60:10", distance: 3.8, sprint: 13, velocity: 15.9, acceleration: 3.0, heartRate: ["max": 183, "min": 91], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.9, sprint: 17, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 169, "min": 79], route: [], center: [0, 0], matchBadge: [-1,2,0]),
-        WorkoutData(dataID: 9, date: "2023-10-27T01:20:32Z", time: "60:10", distance: 5.3, sprint: 12, velocity: 23.5, acceleration: 3.0, heartRate: ["max": 187, "min": 60], route: [], center: [0, 0], matchBadge: [-1,2,0])
+        WorkoutData(dataID: 1, date: "2023-10-09T01:20:32Z", time: "61:10", distance: 3.5, sprint: 3, velocity: 10.5, acceleration: 3.0, heartRate: ["max": 171, "min": 53], route: [], center: [0, 0]),
+        WorkoutData(dataID: 2, date: "2023-10-09T01:20:35Z", time: "62:10", distance: 2.1, sprint: 5, velocity: 11.5, acceleration: 3.0, heartRate: ["max": 152, "min": 70], route: [], center: [0, 0]),
+        WorkoutData(dataID: 3, date: "2023-10-09T01:20:38Z", time: "60:10", distance: 1.1, sprint: 7, velocity: 8.5, acceleration: 3.0, heartRate: ["max": 167, "min": 92], route: [], center: [0, 0]),
+        WorkoutData(dataID: 4, date: "2023-10-19T01:20:32Z", time: "60:10", distance: 5.1, sprint: 9, velocity: 12.5, acceleration: 3.0, heartRate: ["max": 185, "min": 100], route: [], center: [0, 0]),
+        WorkoutData(dataID: 5, date: "2023-10-20T01:20:32Z", time: "60:10", distance: 4.5, sprint: 11, velocity: 17.2, acceleration: 3.0, heartRate: ["max": 175, "min": 60], route: [], center: [0, 0]),
+        WorkoutData(dataID: 6, date: "2023-10-21T01:20:32Z", time: "60:10", distance: 3.6, sprint: 5, velocity: 24.4, acceleration: 3.0, heartRate: ["max": 190, "min": 79], route: [], center: [0, 0]),
+        WorkoutData(dataID: 7, date: "2023-10-23T01:20:32Z", time: "60:10", distance: 3.8, sprint: 13, velocity: 15.9, acceleration: 3.0, heartRate: ["max": 183, "min": 91], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.9, sprint: 17, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 169, "min": 79], route: [], center: [0, 0]),
+        WorkoutData(dataID: 9, date: "2023-10-27T01:20:32Z", time: "60:10", distance: 5.3, sprint: 12, velocity: 23.5, acceleration: 3.0, heartRate: ["max": 187, "min": 60], route: [], center: [0, 0])
     ]
     
     
@@ -106,6 +152,27 @@ struct WorkoutAverageData: Hashable, Equatable, Identifiable {
                                                              sprintCount: 3,
                                                              totalMatchTime: 80)
     
+    init(maxHeartRate: Int, minHeartRate: Int, rangeHeartRate: Int, totalDistance: Double, maxAcceleration: Double, maxVelocity: Double, sprintCount: Int, totalMatchTime: Int) {
+        self.maxHeartRate = maxHeartRate
+        self.minHeartRate = minHeartRate
+        self.rangeHeartRate = rangeHeartRate
+        self.totalDistance = totalDistance
+        self.maxAcceleration = maxAcceleration
+        self.maxVelocity = maxVelocity
+        self.sprintCount = sprintCount
+        self.totalMatchTime = totalMatchTime
+    }
+    
+    init() {
+        self.maxHeartRate = 0
+        self.minHeartRate = 0
+        self.rangeHeartRate = 0
+        self.totalDistance = 0
+        self.maxAcceleration = 0
+        self.maxVelocity = 0
+        self.sprintCount = 0
+        self.totalMatchTime = 0
+    }
 }
 
 extension CLLocationCoordinate2D: Hashable {

--- a/SoccerBeat/SoccerBeat/SoccerBeatApp.swift
+++ b/SoccerBeat/SoccerBeat/SoccerBeatApp.swift
@@ -11,11 +11,14 @@ import SwiftUI
 struct SoccerBeatApp: App {
     @StateObject var soundManager = SoundManager()
     @StateObject var healthInteracter = HealthInteractor.shared
+    @StateObject var profileModel = ProfileModel(healthInteractor: HealthInteractor.shared)
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(soundManager)
                 .environmentObject(healthInteracter)
+                .environmentObject(profileModel)
         }
     }
 }

--- a/SoccerBeat/SoccerBeat/UI/Analytics/AnalyticsComponent.swift
+++ b/SoccerBeat/SoccerBeat/UI/Analytics/AnalyticsComponent.swift
@@ -110,7 +110,7 @@ struct AnalyticsComponent: View {
 
 #Preview {
     ForEach(ActivityEnum.allCases, id: \.self) { act in
-        AnalyticsComponent(userWorkouts: fakeWorkoutData,
+        AnalyticsComponent(userWorkouts: WorkoutData.exampleWorkouts,
                            activityType: act)
     }
     .padding(.horizontal, 16)

--- a/SoccerBeat/SoccerBeat/UI/Charts/BPMChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/BPMChart.swift
@@ -193,6 +193,6 @@ extension BPMChartView {
 
 #Preview {
     NavigationStack {
-        BPMChartView(workouts: fakeWorkoutData)
+        BPMChartView(workouts: WorkoutData.exampleWorkouts)
     }
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/BPMChartOverview.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/BPMChartOverview.swift
@@ -36,5 +36,5 @@ struct BPMChartOverview: View {
 }
 
 #Preview {
-    BPMChartOverview(workouts: fakeWorkoutData)
+    BPMChartOverview(workouts: WorkoutData.exampleWorkouts)
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/DistanceChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/DistanceChart.swift
@@ -190,6 +190,6 @@ extension DistanceChartView {
 
 #Preview {
     NavigationStack {
-        DistanceChartView(workouts: fakeWorkoutData)
+        DistanceChartView(workouts: WorkoutData.exampleWorkouts)
     }
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/DistanceChartOverview.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/DistanceChartOverview.swift
@@ -32,5 +32,5 @@ struct DistanceChartOverview: View {
 }
 
 #Preview {
-    DistanceChartOverview(workouts: fakeWorkoutData)
+    DistanceChartOverview(workouts: WorkoutData.exampleWorkouts)
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/SpeedChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/SpeedChart.swift
@@ -190,22 +190,8 @@ extension SpeedChartView {
     }
 }
 
-let fakeWorkoutData: [WorkoutData] = [
-    WorkoutData(dataID: 1,
-                date: "2024-1-23",
-                time: "130",
-                distance: 7,
-                sprint: 3,
-                velocity: 15,
-                acceleration: 0,
-                heartRate: [:],
-                route: [],
-                center: [],
-                matchBadge: [])
-]
-
 #Preview {
     NavigationStack {
-        SpeedChartView(workouts: fakeWorkoutData)
+        SpeedChartView(workouts: WorkoutData.exampleWorkouts)
     }
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/SpeedChartOverview.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/SpeedChartOverview.swift
@@ -32,5 +32,5 @@ struct SpeedChartOverview: View {
 }
 
 #Preview {
-    SpeedChartOverview(workouts: fakeWorkoutData)
+    SpeedChartOverview(workouts: WorkoutData.exampleWorkouts)
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/SprintChart.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/SprintChart.swift
@@ -191,6 +191,6 @@ extension SprintChartView {
 
 #Preview {
     NavigationStack {
-        SprintChartView(workouts: fakeWorkoutData)
+        SprintChartView(workouts: WorkoutData.exampleWorkouts)
     }
 }

--- a/SoccerBeat/SoccerBeat/UI/Charts/SprintChartOverview.swift
+++ b/SoccerBeat/SoccerBeat/UI/Charts/SprintChartOverview.swift
@@ -36,5 +36,5 @@ struct SprintChartOverview: View {
 }
 
 #Preview {
-    SprintChartOverview(workouts: fakeWorkoutData)
+    SprintChartOverview(workouts: WorkoutData.exampleWorkouts)
 }

--- a/SoccerBeat/SoccerBeat/UI/Screens/ContentView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/ContentView.swift
@@ -13,42 +13,19 @@ struct ContentView: View {
     @EnvironmentObject var soundManager: SoundManager
     
     @AppStorage("healthAlert") var healthAlert = true
-    @State var workoutData: [WorkoutData]?
-    @State var userWorkouts: [WorkoutData] = []
-    @State var averageData: WorkoutAverageData = WorkoutAverageData(maxHeartRate: 0,
-                                                                    minHeartRate: 0,
-                                                                    rangeHeartRate: 0,
-                                                                    totalDistance: 0.0,
-                                                                    maxAcceleration: 0,
-                                                                    maxVelocity: 0.0,
-                                                                    sprintCount: 0,
-                                                                    totalMatchTime: 0)
-    @State var maximumData: WorkoutAverageData = WorkoutAverageData(maxHeartRate: 0,
-                                                                    minHeartRate: 0,
-                                                                    rangeHeartRate: 0,
-                                                                    totalDistance: 0.0,
-                                                                    maxAcceleration: 0,
-                                                                    maxVelocity: 0.0,
-                                                                    sprintCount: 0,
-                                                                    totalMatchTime: 0)
-    
-    @StateObject var viewModel = ProfileModel()
+    @State private var workouts: [WorkoutData] = []
     
     var body: some View {
         NavigationStack {
             ZStack {
+                // TODO: - 건강 경보라고만 되어있는데 어떤 경보인지 알 수 있도록 renaming
                 if healthAlert {
                     HealthAlertView(showingAlert: $healthAlert)
                 } else {
-                    if let _ = self.workoutData {
-                        MainView(userWorkouts: $userWorkouts,
-                                 averageData: $averageData,
-                                 maximumData: $maximumData,
-                                 viewModel: viewModel)
+                    if workouts.isEmpty {
+                        EmptyDataView()
                     } else {
-                        // No soccer data OR,
-                        // User does not allow permisson.
-                        EmptyDataView(viewModel: viewModel, maximumData: $maximumData)
+                        MainView(workouts: $workouts)
                     }
                 }
             }
@@ -58,11 +35,8 @@ struct ContentView: View {
             .onReceive(healthInteractor.authSuccess) {
                 Task { await healthInteractor.fetchWorkoutData() }
             }
-            .onReceive(healthInteractor.fetchSuccess) {
-                self.workoutData = healthInteractor.workoutData
-                self.averageData = healthInteractor.userAverage
-                self.maximumData = healthInteractor.userMaximum
-                self.userWorkouts = workoutData!
+            .onReceive(healthInteractor.fetchWorkoutsSuccess) { workouts in
+                self.workouts = workouts
             }
             .onAppear {
                 // 음악을 틀기
@@ -76,6 +50,6 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(userWorkouts: [])
+    ContentView()
         .preferredColorScheme(.dark)
 }

--- a/SoccerBeat/SoccerBeat/UI/Screens/EmptyDataView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/EmptyDataView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 struct EmptyDataView: View {
     @State var workoutAverageData: WorkoutAverageData = WorkoutAverageData(maxHeartRate: 0, minHeartRate: 0, rangeHeartRate: 0, totalDistance: 0, maxAcceleration: 0, maxVelocity: 0, sprintCount: 0, totalMatchTime: 0)
     @EnvironmentObject var soundManager: SoundManager
-    @ObservedObject var viewModel: ProfileModel
-    @Binding var maximumData: WorkoutAverageData
+    @EnvironmentObject var viewModel: ProfileModel
     
     @State var isShowingBug = false
     let alertTitle: String = "문제가 있으신가요?"
@@ -81,9 +80,9 @@ struct EmptyDataView: View {
                     }
                     Spacer()
                     NavigationLink {
-                        ProfileView(viewModel: viewModel, averageData: $workoutAverageData, maximumData: $maximumData)
+                        ProfileView()
                     } label: {
-                        CardFront(viewModel: viewModel, degree: .constant(0), width: 72, height: 96)
+                        CardFront(degree: .constant(0), width: 72, height: 96)
                     }
                 }
                 .padding()

--- a/SoccerBeat/SoccerBeat/UI/Screens/MainView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MainView.swift
@@ -10,15 +10,10 @@ import SwiftUI
 struct MainView: View {
     @EnvironmentObject var healthInteractor: HealthInteractor
     @EnvironmentObject var soundManager: SoundManager
-    
-    @Binding var userWorkouts: [WorkoutData]
-    @State var updateUserWorkouts: [WorkoutData]?
-    @Binding var averageData: WorkoutAverageData
-    @Binding var maximumData: WorkoutAverageData
-    
-    @State var isFlipped: Bool = false
-    @ObservedObject var viewModel: ProfileModel
+    @EnvironmentObject var viewModel: ProfileModel
+    @State private var isFlipped = false
     @State private var currentLocation = "---"
+    @Binding var workouts: [WorkoutData]
     
     @State var isShowingBug = false
     let alertTitle: String = "문제가 있으신가요?"
@@ -79,7 +74,7 @@ struct MainView: View {
                 
                 HStack(alignment: .bottom) {
                     VStack(alignment: .leading) {
-                        Text(userWorkouts[0].yearMonthDay)
+                        Text(workouts[0].yearMonthDay)
                             .font(.mainSubTitleText)
                             .opacity(0.7)
                         Text("최근 경기")
@@ -87,64 +82,33 @@ struct MainView: View {
                     }
                     Spacer()
                     NavigationLink {
-                        ProfileView(viewModel: viewModel, averageData: $averageData, maximumData: $maximumData)
+                        ProfileView()
                     } label: {
-                        CardFront(viewModel: viewModel, degree: .constant(0), width: 72, height: 110)
+                        CardFront(degree: .constant(0), width: 72, height: 110)
                     }
                 }
                 .padding()
                 
                 NavigationLink {
-                    MatchDetailView(workoutData: userWorkouts[0], averageData: $averageData, maximumData: $maximumData)
+                    MatchDetailView(workoutData: workouts[0])
                 } label: {
                     ZStack {
                         LightRectangleView(alpha: 0.6, color: .black, radius: 15)
                         HStack {
                             VStack {
                                 HStack {
-                                    // MARK: 프리뷰 보려면 스파이더 맵 포함 하단의 변수들 각주 처리해주세요 -
-                                    let averageLevel = DataConverter.dataConverter(totalDistance: averageData.totalDistance,
-                                                                                   maxHeartRate: averageData.maxHeartRate,
-                                                                                   maxVelocity: averageData.maxVelocity,
-                                                                                   maxAcceleration: averageData.maxAcceleration,
-                                                                                   sprintCount: averageData.sprintCount,
-                                                                                   minHeartRate: averageData.minHeartRate,
-                                                                                   rangeHeartRate: averageData.rangeHeartRate,
-                                                                                   totalMatchTime: averageData.totalMatchTime)
-                                    let average = [(averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                                                   (averageLevel["maxVelocity"] ?? 1.0) * 0.3 + (averageLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                                                   (averageLevel["maxVelocity"] ?? 1.0) * 0.25 + (averageLevel["sprintCount"] ?? 1.0) * 0.125 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                                                   (averageLevel["maxAcceleration"] ?? 1.0) * 0.4 + (averageLevel["minHeartRate"] ?? 1.0) * 0.1,
-                                                   (averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (averageLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                                                   (averageLevel["totalDistance"] ?? 1.0) * 0.3 + (averageLevel["sprintCount"] ?? 1.0) * 0.1 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.1]
+//                                    RadarChartView(workout: workouts[0])
+//                                        .scaleEffect(CGSize(width: 0.7, height: 0.7))
+//                                        .frame(width: 210, height: 210)
+//                                        .fixedSize()
+//                                        .border(.yellow)
                                     
-                                    let rawTime = userWorkouts[0].time
-                                    let separatedTime = rawTime.components(separatedBy: ":")
-                                    let separatedMinutes = separatedTime[0].trimmingCharacters(in: .whitespacesAndNewlines)
-                                    let separatedSeconds = separatedTime[1].trimmingCharacters(in: .whitespacesAndNewlines)
-                                    let recentLevel = DataConverter.dataConverter(totalDistance: userWorkouts[0].distance,
-                                                                                  maxHeartRate: userWorkouts[0].maxHeartRate,
-                                                                                  maxVelocity: userWorkouts[0].velocity,
-                                                                                  maxAcceleration: userWorkouts[0].acceleration,
-                                                                                  sprintCount: userWorkouts[0].sprint,
-                                                                                  minHeartRate: userWorkouts[0].minHeartRate,
-                                                                                  rangeHeartRate: userWorkouts[0].maxHeartRate - userWorkouts[0].minHeartRate,
-                                                                                  totalMatchTime: Int(separatedMinutes)! * 60 + Int(separatedSeconds)!)
-                                    let recent = [(recentLevel["totalDistance"] ?? 1.0) * 0.15 + (recentLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                                                  (recentLevel["maxVelocity"] ?? 1.0) * 0.3 + (recentLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                                                  (recentLevel["maxVelocity"] ?? 1.0) * 0.25 + (recentLevel["sprintCount"] ?? 1.0) * 0.125 + (recentLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                                                  (recentLevel["maxAcceleration"] ?? 1.0) * 0.4 + (recentLevel["minHeartRate"] ?? 1.0) * 0.1,
-                                                  (recentLevel["totalDistance"] ?? 1.0) * 0.15 + (recentLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (recentLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                                                  (recentLevel["totalDistance"] ?? 1.0) * 0.3 + (recentLevel["sprintCount"] ?? 1.0) * 0.1 + (recentLevel["maxHeartRate"] ?? 1.0) * 0.1]
-                                    
-                                    // 방구석 리뷰룸 시연을 위해 작성한 코드
-                                    let tripleAverage = average.map { min($0 * 3, 5.0) }
-                                    let tripleRecent = recent.map { min($0 * 3, 5.0) }
-                                    
-                                    ViewControllerContainer(RadarViewController(radarAverageValue: tripleAverage, radarAtypicalValue: tripleRecent))
+                                    RadarChartView(workout: workouts[0], width: 210, height: 210)
                                         .scaleEffect(CGSize(width: 0.7, height: 0.7))
+//                                        .frame(width: 210, height: 210)
                                         .fixedSize()
-                                        .frame(width: 210, height: 210)
+                                        .border(.yellow)
+                                    
                                     Spacer()
                                     
                                     // 최근 경기 미리보기 오른쪽
@@ -156,11 +120,11 @@ struct MainView: View {
                                                 .foregroundStyle(.mainDateTime)
                                                 .opacity(0.8)
                                                 .task {
-                                                    currentLocation = await userWorkouts[0].location
+                                                    currentLocation = await workouts[0].location
                                                 }
                                             Group {
                                                 Text("경기 시간")
-                                                Text(userWorkouts[0].time)
+                                                Text(workouts[0].time)
                                             }
                                             .font(.mainTime)
                                             .foregroundStyle(.mainMatchTime)
@@ -170,8 +134,8 @@ struct MainView: View {
                                         
                                         // 뱃지
                                         HStack {
-                                            ForEach(userWorkouts[0].matchBadge.indices, id: \.self) { index in
-                                                if let badgeName = ShortenedBadgeImageDictionary[index][userWorkouts[0].matchBadge[index]] {
+                                            ForEach(workouts[0].matchBadge.indices, id: \.self) { index in
+                                                if let badgeName = ShortenedBadgeImageDictionary[index][workouts[0].matchBadge[index]] {
                                                     if badgeName.isEmpty {
                                                         EmptyView()
                                                     } else {
@@ -180,8 +144,6 @@ struct MainView: View {
                                                             .aspectRatio(contentMode: .fit)
                                                             .frame(width: 32, height: 36)
                                                     }
-                                                } else {
-                                                    EmptyView()
                                                 }
                                             }
                                         }
@@ -196,7 +158,7 @@ struct MainView: View {
                 
                 NavigationLink {
                     ScrollView(showsIndicators: false) {
-                        MatchRecapView(userWorkouts: $userWorkouts, averageData: $averageData, maximumData: $maximumData)
+                        MatchRecapView(userWorkouts: workouts)
                     }
                 } label: {
                     ZStack {
@@ -234,13 +196,6 @@ struct MainView: View {
                 await healthInteractor.fetchWorkoutData()
             }
         })
-        .onReceive(healthInteractor.fetchSuccess, perform: {
-            print("ContentView: fetching user data success..")
-            self.updateUserWorkouts = healthInteractor.workoutData
-            self.averageData = healthInteractor.userAverage
-            self.maximumData = healthInteractor.userMaximum
-            self.userWorkouts = updateUserWorkouts!
-        })
         
         .padding(.horizontal)
         .navigationTitle("")
@@ -266,4 +221,16 @@ struct MainView: View {
         return defaultUrl
     }
 
+}
+
+#Preview {
+    @StateObject var health = HealthInteractor.shared
+    @StateObject var sound = SoundManager()
+    @StateObject var profileModel = ProfileModel(healthInteractor: .shared)
+    @State var workouts = WorkoutData.exampleWorkouts
+    
+    return MainView(workouts: $workouts)
+        .environmentObject(health)
+        .environmentObject(sound)
+        .environmentObject(profileModel)
 }

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchDetailView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchDetailView.swift
@@ -12,9 +12,6 @@ import CoreLocation
 struct MatchDetailView: View {
     let workoutData: WorkoutData
     
-    @Binding var averageData: WorkoutAverageData
-    @Binding var maximumData: WorkoutAverageData
-    
     var body: some View {
         ScrollView(showsIndicators: false) {
             ZStack {
@@ -22,7 +19,7 @@ struct MatchDetailView: View {
                     MatchTimeView(workoutData: workoutData)
                     Spacer()
                         .frame(height: 48)
-                    PlayerAbilityView(averageData: $averageData, maximumData: $maximumData, workoutData: workoutData)
+                    PlayerAbilityView(workoutData: workoutData)
                         .zIndex(-1)
                     Spacer()
                         .frame(height: 100)
@@ -63,9 +60,6 @@ struct MatchTimeView: View {
 }
 
 struct PlayerAbilityView: View {
-    @Binding var averageData: WorkoutAverageData
-    @Binding var maximumData: WorkoutAverageData
-    
     let workoutData: WorkoutData
     var body: some View {
         VStack {
@@ -94,49 +88,14 @@ struct PlayerAbilityView: View {
                     }
                     HStack {
                         Spacer()
-                        // TODO: - DataConverter의 코드가 중복됨 3
-                        let averageLevel = DataConverter.dataConverter(totalDistance: averageData.totalDistance,
-                                                         maxHeartRate: averageData.maxHeartRate,
-                                                         maxVelocity: averageData.maxVelocity,
-                                                         maxAcceleration: averageData.maxAcceleration,
-                                                         sprintCount: averageData.sprintCount,
-                                                         minHeartRate: averageData.minHeartRate,
-                                                         rangeHeartRate: averageData.rangeHeartRate,
-                                                         totalMatchTime: averageData.totalMatchTime)
-                        let average = [(averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                                       (averageLevel["maxVelocity"] ?? 1.0) * 0.3 + (averageLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                                       (averageLevel["maxVelocity"] ?? 1.0) * 0.25 + (averageLevel["sprintCount"] ?? 1.0) * 0.125 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                                       (averageLevel["maxAcceleration"] ?? 1.0) * 0.4 + (averageLevel["minHeartRate"] ?? 1.0) * 0.1,
-                                       (averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (averageLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                                       (averageLevel["totalDistance"] ?? 1.0) * 0.3 + (averageLevel["sprintCount"] ?? 1.0) * 0.1 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.1]
+//                        RadarChartView(workout: workoutData)
+//                            .fixedSize()
+//                            .frame(width: 304, height: 348)
+//                            .zIndex(-1)
                         
-                        let rawTime = workoutData.time
-                        let separatedTime = rawTime.components(separatedBy: ":")
-                        let separatedMinutes = separatedTime[0].trimmingCharacters(in: .whitespacesAndNewlines)
-                        let separatedSeconds = separatedTime[1].trimmingCharacters(in: .whitespacesAndNewlines)
-                        let matchLevel = DataConverter.dataConverter(totalDistance: workoutData.distance,
-                                                       maxHeartRate: workoutData.maxHeartRate,
-                                                       maxVelocity: workoutData.velocity,
-                                                       maxAcceleration: workoutData.acceleration,
-                                                       sprintCount: workoutData.sprint,
-                                                       minHeartRate: workoutData.minHeartRate,
-                                                       rangeHeartRate: workoutData.maxHeartRate - workoutData.minHeartRate,
-                                                       totalMatchTime: Int(separatedMinutes)! * 60 + Int(separatedSeconds)!)
-                        let recent = [(matchLevel["totalDistance"] ?? 1.0) * 0.15 + (matchLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                                      (matchLevel["maxVelocity"] ?? 1.0) * 0.3 + (matchLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                                      (matchLevel["maxVelocity"] ?? 1.0) * 0.25 + (matchLevel["sprintCount"] ?? 1.0) * 0.125 + (matchLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                                      (matchLevel["maxAcceleration"] ?? 1.0) * 0.4 + (matchLevel["minHeartRate"] ?? 1.0) * 0.1,
-                                      (matchLevel["totalDistance"] ?? 1.0) * 0.15 + (matchLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (matchLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                                      (matchLevel["totalDistance"] ?? 1.0) * 0.3 + (matchLevel["sprintCount"] ?? 1.0) * 0.1 + (matchLevel["maxHeartRate"] ?? 1.0) * 0.1]
-                        
-                        
-                        // 방구석 리뷰룸 시연을 위해 작성한 코드
-                        let tripleAverage = average.map { min($0 * 3, 5.0) }
-                        let tripleRecent = recent.map { min($0 * 3, 5.0) }
-                        
-                        ViewControllerContainer(RadarViewController(radarAverageValue: tripleAverage, radarAtypicalValue: tripleRecent))
+                        RadarChartView(workout: workoutData,width: 304, height: 348)
                             .fixedSize()
-                            .frame(width: 304, height: 348)
+//                            .frame(width: 304, height: 348)
                             .zIndex(-1)
                         
                         Spacer()
@@ -221,9 +180,7 @@ struct FieldMovementView: View {
 
 #Preview {
     @StateObject var healthInteractor = HealthInteractor.shared
-    return MatchDetailView(workoutData: WorkoutData.example,
-                           averageData: .constant(WorkoutAverageData.exampleAverage),
-                           maximumData: .constant(WorkoutAverageData.exampleAverage))
+    return MatchDetailView(workoutData: WorkoutData.example)
     .environmentObject(healthInteractor)
 }
 

--- a/SoccerBeat/SoccerBeat/UI/Screens/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MatchRecapView.swift
@@ -8,12 +8,8 @@
 import SwiftUI
 
 struct MatchRecapView: View {
-    
-    @EnvironmentObject var healthInteractor: HealthInteractor
-    @Binding var userWorkouts: [WorkoutData]
-    @Binding var averageData: WorkoutAverageData
-    @Binding var maximumData: WorkoutAverageData
-    @State var userName: String = ""
+    let userWorkouts: [WorkoutData]
+    @State private var userName = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -49,14 +45,12 @@ struct MatchRecapView: View {
             .padding(.leading, 32)
             
             VStack(spacing: 15) {
-                ForEach(userWorkouts ?? [], id: \.self) { workout in
+                ForEach(userWorkouts) { workout in
                     NavigationLink {
-                        MatchDetailView(workoutData: workout,
-                                        averageData: $averageData,
-                                        maximumData: $maximumData)
+                        MatchDetailView(workoutData: workout)
                         .toolbarRole(.editor)
                     } label: {
-                        MatchListItemView(workoutData: workout, averageData: $averageData)
+                        MatchListItemView(workoutData: workout)
                     }
                 }
             }
@@ -72,7 +66,6 @@ struct MatchRecapView: View {
 struct MatchListItemView: View {
     let workoutData: WorkoutData
     @State private var currentLocation = "--'--"
-    @Binding var averageData: WorkoutAverageData
     
     var body: some View {
         ZStack {
@@ -102,49 +95,11 @@ struct MatchListItemView: View {
             
             HStack {
                 Spacer ()
-                // TODO: - DataConverter의 코드가 중복됨 2
-                let averageLevel = DataConverter.dataConverter(totalDistance: averageData.totalDistance,
-                                                 maxHeartRate: averageData.maxHeartRate,
-                                                 maxVelocity: averageData.maxVelocity,
-                                                 maxAcceleration: averageData.maxAcceleration,
-                                                 sprintCount: averageData.sprintCount,
-                                                 minHeartRate: averageData.minHeartRate,
-                                                 rangeHeartRate: averageData.rangeHeartRate,
-                                                 totalMatchTime: averageData.totalMatchTime)
-                let average = [(averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                               (averageLevel["maxVelocity"] ?? 1.0) * 0.3 + (averageLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                               (averageLevel["maxVelocity"] ?? 1.0) * 0.25 + (averageLevel["sprintCount"] ?? 1.0) * 0.125 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                               (averageLevel["maxAcceleration"] ?? 1.0) * 0.4 + (averageLevel["minHeartRate"] ?? 1.0) * 0.1,
-                               (averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (averageLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                               (averageLevel["totalDistance"] ?? 1.0) * 0.3 + (averageLevel["sprintCount"] ?? 1.0) * 0.1 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.1]
                 
-                let rawTime = workoutData.time
-                let separatedTime = rawTime.components(separatedBy: ":")
-                let separatedMinutes = separatedTime[0].trimmingCharacters(in: .whitespacesAndNewlines)
-                let separatedSeconds = separatedTime[1].trimmingCharacters(in: .whitespacesAndNewlines)
-                let recentLevel = DataConverter.dataConverter(totalDistance: workoutData.distance,
-                                                maxHeartRate: workoutData.maxHeartRate,
-                                                maxVelocity: workoutData.velocity,
-                                                maxAcceleration: workoutData.acceleration,
-                                                sprintCount: workoutData.sprint,
-                                                minHeartRate: workoutData.minHeartRate,
-                                                rangeHeartRate: workoutData.maxHeartRate - workoutData.minHeartRate,
-                                                totalMatchTime: Int(separatedMinutes)! * 60 + Int(separatedSeconds)!)
-                let recent = [(recentLevel["totalDistance"] ?? 1.0) * 0.15 + (recentLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                              (recentLevel["maxVelocity"] ?? 1.0) * 0.3 + (recentLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                              (recentLevel["maxVelocity"] ?? 1.0) * 0.25 + (recentLevel["sprintCount"] ?? 1.0) * 0.125 + (recentLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                              (recentLevel["maxAcceleration"] ?? 1.0) * 0.4 + (recentLevel["minHeartRate"] ?? 1.0) * 0.1,
-                              (recentLevel["totalDistance"] ?? 1.0) * 0.15 + (recentLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (recentLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                              (recentLevel["totalDistance"] ?? 1.0) * 0.3 + (recentLevel["sprintCount"] ?? 1.0) * 0.1 + (recentLevel["maxHeartRate"] ?? 1.0) * 0.1]
-                
-                // 방구석 리뷰룸 시연을 위해 작성한 코드
-                let tripleAverage = average.map { min($0 * 3, 5.0) }
-                let tripleRecent = recent.map { min($0 * 3, 5.0) }
-                
-                ViewControllerContainer(ThumbnailViewController(radarAverageValue: tripleAverage, radarAtypicalValue: tripleRecent))
+                RadarChartView(workout: workoutData, width: 88, height: 88)
                     .scaleEffect(CGSize(width: 0.4, height: 0.4))
                     .fixedSize()
-                    .frame(width: 88, height: 88)
+//                    .frame(width: 88, height: 88)
  
                 VStack(alignment: .leading) {
                     Group {
@@ -193,9 +148,5 @@ struct MatchListItemView: View {
 }
 
 #Preview {
-    @StateObject var healthInteractor = HealthInteractor.shared
-    return MatchRecapView(userWorkouts: .constant(WorkoutData.exampleWorkouts),
-                          averageData: .constant(WorkoutAverageData.exampleAverage),
-                          maximumData: .constant(WorkoutAverageData.exampleAverage))
-    .environmentObject(healthInteractor)
+    MatchRecapView(userWorkouts: WorkoutData.exampleWorkouts)
 }

--- a/SoccerBeat/SoccerBeat/UI/Screens/MyCardView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/MyCardView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct MyCardView: View {
     @EnvironmentObject var soundManager: SoundManager
-    @ObservedObject var viewModel: ProfileModel
+    @EnvironmentObject var viewModel: ProfileModel
     @State private var backDegree = 0.0
     @State private var frontDegree = -90.0
     @Binding var isFlipped: Bool
@@ -23,7 +23,7 @@ struct MyCardView: View {
         ZStack {
             VStack {
                 ZStack {
-                    CardFront(viewModel: viewModel, degree: $frontDegree, width: width, height: height)
+                    CardFront(degree: $frontDegree, width: width, height: height)
                     CardBack(degree: $backDegree, width: width, height: height)
                 }
                 .onTapGesture {
@@ -61,7 +61,7 @@ struct MyCardView: View {
 }
 
 struct CardFront : View {
-    @ObservedObject var viewModel: ProfileModel
+    @EnvironmentObject var viewModel: ProfileModel
     @State private var selectedItem: PhotosPickerItem?
     @Binding var degree : Double
     let width : CGFloat
@@ -69,8 +69,7 @@ struct CardFront : View {
     
     var body: some View {
         ZStack {
-            Profile(viewModel: viewModel,
-                    width: width,
+            Profile(width: width,
                     height: height)
                 
             Image(.profileLayer)
@@ -97,5 +96,5 @@ struct CardBack : View {
 }
 
 #Preview {
-    MyCardView(viewModel: ProfileModel(), isFlipped: .constant(true))
+    MyCardView(isFlipped: .constant(true))
 }

--- a/SoccerBeat/SoccerBeat/UI/Screens/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/ProfileView.swift
@@ -8,13 +8,11 @@
 import SwiftUI
 
 struct ProfileView: View {
-    @ObservedObject var viewModel: ProfileModel
+    @EnvironmentObject var viewModel: ProfileModel
     @State private var isFlipped = false
     @State private var userName = ""
     @State private var userImage: UIImage?
     @FocusState private var isFocused: Bool
-    @Binding var averageData: WorkoutAverageData
-    @Binding var maximumData: WorkoutAverageData
     
     var body: some View {
         NavigationStack {
@@ -67,7 +65,7 @@ struct ProfileView: View {
                                 .font(.custom("SFProDisplay-HeavyItalic", size: 36))
                                 
                                 VStack {
-                                    MyCardView(viewModel: viewModel, isFlipped: $isFlipped)
+                                    MyCardView(isFlipped: $isFlipped)
                                         .frame(width: 105)
                                     PhotoSelectButtonView(viewModel: viewModel)
                                         .opacity(isFlipped ? 1 : 0)
@@ -109,50 +107,12 @@ struct ProfileView: View {
                         }
                     }
                     
-                    // TODO: - DataConverter의 코드가 중복됨 1
-                    let averageLevel = DataConverter.dataConverter(totalDistance: averageData.totalDistance,
-                                                     maxHeartRate: averageData.maxHeartRate,
-                                                     maxVelocity: averageData.maxVelocity,
-                                                     maxAcceleration: averageData.maxAcceleration,
-                                                     sprintCount: averageData.sprintCount,
-                                                     minHeartRate: averageData.minHeartRate,
-                                                     rangeHeartRate: averageData.rangeHeartRate,
-                                                     totalMatchTime: averageData.totalMatchTime)
-                    let average = [(averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                                   (averageLevel["maxVelocity"] ?? 1.0) * 0.3 + (averageLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                                   (averageLevel["maxVelocity"] ?? 1.0) * 0.25 + (averageLevel["sprintCount"] ?? 1.0) * 0.125 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                                   (averageLevel["maxAcceleration"] ?? 1.0) * 0.4 + (averageLevel["minHeartRate"] ?? 1.0) * 0.1,
-                                   (averageLevel["totalDistance"] ?? 1.0) * 0.15 + (averageLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (averageLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                                   (averageLevel["totalDistance"] ?? 1.0) * 0.3 + (averageLevel["sprintCount"] ?? 1.0) * 0.1 + (averageLevel["maxHeartRate"] ?? 1.0) * 0.1]
-                    
-                    let maximumLevel = DataConverter.dataConverter(totalDistance: maximumData.totalDistance,
-                                                     maxHeartRate: maximumData.maxHeartRate,
-                                                     maxVelocity: maximumData.maxVelocity,
-                                                     maxAcceleration: maximumData.maxAcceleration,
-                                                     sprintCount: maximumData.sprintCount,
-                                                     minHeartRate: maximumData.minHeartRate,
-                                                     rangeHeartRate: maximumData.rangeHeartRate,
-                                                     totalMatchTime: maximumData.totalMatchTime)
-                    let recent = [(maximumLevel["totalDistance"] ?? 1.0) * 0.15 + (maximumLevel["maxHeartRate"] ?? 1.0) * 0.35,
-                                  (maximumLevel["maxVelocity"] ?? 1.0) * 0.3 + (maximumLevel["maxAcceleration"] ?? 1.0) * 0.2,
-                                  (maximumLevel["maxVelocity"] ?? 1.0) * 0.25 + (maximumLevel["sprintCount"] ?? 1.0) * 0.125 + (maximumLevel["maxHeartRate"] ?? 1.0) * 0.125,
-                                  (maximumLevel["maxAcceleration"] ?? 1.0) * 0.4 + (maximumLevel["minHeartRate"] ?? 1.0) * 0.1,
-                                  (maximumLevel["totalDistance"] ?? 1.0) * 0.15 + (maximumLevel["rangeHeartRate"] ?? 1.0) * 0.15 + (maximumLevel["totalMatchTime"] ?? 1.0) * 0.2,
-                                  (maximumLevel["totalDistance"] ?? 1.0) * 0.3 + (maximumLevel["sprintCount"] ?? 1.0) * 0.1 + (maximumLevel["maxHeartRate"] ?? 1.0) * 0.1]
-                    
-                    // 방구석 리뷰룸 시연을 위해 작성한 코드
-                    let tripleAverage = average.map { min($0 * 3, 5.0) }
-                    let tripleRecent = recent.map { min($0 * 3, 5.0) }
-                    
-                    ViewControllerContainer(ProfileViewController(radarAverageValue: tripleAverage, radarAtypicalValue: tripleRecent))
-                        .fixedSize()
-                        .frame(width: 304, height: 348)
-                        .zIndex(-1)
+                    RadarChartView(width: 304, height: 348)
+//                        .frame(width: 304, height: 348)
                     
                     Spacer()
                         .frame(height: 110)
-                    
-                    
+
                     TrophyCollectionView()
                     
                 }
@@ -166,7 +126,7 @@ struct ProfileView: View {
         }
         .toolbar {
             NavigationLink {
-                ShareView(viewModel: viewModel)
+                ShareView()
             } label: {
                 Text("공유하기")
                     .foregroundStyle(.shareViewTitleTint)

--- a/SoccerBeat/SoccerBeat/UI/Screens/RadarChartView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/RadarChartView.swift
@@ -1,0 +1,44 @@
+//
+//  RadarChartView.swift
+//  SoccerBeat
+//
+//  Created by Gucci on 3/24/24.
+//
+
+import SwiftUI
+
+struct RadarChartView: View {
+    @EnvironmentObject var profileModel: ProfileModel
+    let workout: WorkoutData?
+    let width: Double
+    let height: Double
+    
+    init(workout: WorkoutData? = nil, width: Double, height: Double) {
+        self.workout = workout
+        self.width = width
+        self.height = height 
+    }
+    
+    var body: some View {
+        
+        let recentLevel = DataConverter.toLevels(workout ?? .blankExample)
+        let averageLevel = DataConverter.toLevels(profileModel.averageAbility)
+        
+        /*
+        // 방구석 리뷰룸 시연을 위해 작성한 코드
+        let tripleAverage = average.map { min($0 * 3, 5.0) }
+        let tripleRecent = recent.map { min($0 * 3, 5.0) }
+        */
+        
+        ViewControllerContainer(RadarViewController(radarAverageValue: averageLevel,
+                                                    radarAtypicalValue: recentLevel))
+        .frame(width: width, height: height)
+    }
+}
+
+#Preview {
+    @StateObject var profileModel = ProfileModel(healthInteractor: HealthInteractor.shared)
+    
+    return RadarChartView(workout: .example, width: 100, height: 100)
+            .environmentObject(profileModel)
+}

--- a/SoccerBeat/SoccerBeat/UI/Screens/ShareView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Screens/ShareView.swift
@@ -8,17 +8,14 @@
 import SwiftUI
 
 struct ShareView: View {
-    @StateObject var healthInteractor = HealthInteractor.shared
-    @ObservedObject var viewModel: ProfileModel
     @State var geoSize = CGSize(width: 0, height: 0)
-    @State var highresImage: UIImage = UIImage()
+    @State var highresImage = UIImage()
     @State var renderImage: UIImage?
     
     var body: some View {
         VStack {
             GeometryReader { geo in
-                TargetImageView(cgSize: geo.size, degree: 0, viewModel: viewModel)
-                    .environmentObject(healthInteractor)
+                TargetImageView(cgSize: geo.size, degree: 0)
                     .onAppear {
                         self.geoSize = CGSize(width: geo.size.width, height: geo.size.height)
                     }
@@ -26,8 +23,7 @@ struct ShareView: View {
         }
         .toolbar {
             Button {
-                renderImage = TargetImageView(cgSize: self.geoSize, viewModel: viewModel)
-                .environmentObject(healthInteractor)
+                renderImage = TargetImageView(cgSize: self.geoSize)
                                     .asImage(size: self.geoSize)
                 share()
             } label: {
@@ -43,9 +39,7 @@ struct ShareView: View {
 }
 
 #Preview {
-    @StateObject var viewModel = ProfileModel()
-    
-    return ShareView(viewModel: viewModel)
+    ShareView()
 }
 
 extension UIScreen {
@@ -74,10 +68,10 @@ extension View {
 }
 
 struct TargetImageView: View {
+    @EnvironmentObject var viewModel: ProfileModel
+    @EnvironmentObject var healthInteractor: HealthInteractor
     @State var cgSize: CGSize
     @State var degree: Double = 0
-    @ObservedObject var viewModel: ProfileModel
-    @EnvironmentObject var healthInteractor: HealthInteractor
     private var userName: String {
         return UserDefaults.standard.string(forKey: "userName") ?? "닉네임"
     }
@@ -91,7 +85,7 @@ struct TargetImageView: View {
             VStack {
                 Spacer()
                 HStack(alignment: .bottom) {
-                    CardFront(viewModel: viewModel, degree: $degree, width: 100, height: 140)
+                    CardFront(degree: $degree, width: 100, height: 140)
                     VStack(alignment: .leading, spacing: 0) {
                         Text("# Soccer Beat")
                             .floatingCapsuleStyle()
@@ -148,12 +142,12 @@ extension TargetImageView {
     @ViewBuilder
     private var currentBadge: some View {
         VStack(alignment: .leading, spacing: 31) {
-            ForEach(0..<healthInteractor.allBadges.count, id: \.self) { sortIndex in
+            ForEach(0..<viewModel.allBadges.count) { sortIndex in
                 VStack(alignment: .leading, spacing: 10) {
                     floatingBadgeInfo(at: sortIndex)
                     HStack {
-                        ForEach(0..<healthInteractor.allBadges[sortIndex].count, id: \.self) { levelIndex in
-                            let isOpened = healthInteractor.allBadges[sortIndex][levelIndex]
+                        ForEach(0..<viewModel.allBadges[sortIndex].count, id: \.self) { levelIndex in
+                            let isOpened = viewModel.allBadges[sortIndex][levelIndex]
                             
                             TrophyView(sort: sortIndex, level: levelIndex, isOpened: isOpened)
                                 .frame(width: 74, height: 82)
@@ -166,5 +160,5 @@ extension TargetImageView {
 }
 
 #Preview {
-    ShareView(viewModel: ProfileModel())
+    ShareView()
 }

--- a/SoccerBeat/SoccerBeat/UI/Trophy/TrophyCollectionView.swift
+++ b/SoccerBeat/SoccerBeat/UI/Trophy/TrophyCollectionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TrophyCollectionView: View {
-    @EnvironmentObject var healthInteractor: HealthInteractor
+    @EnvironmentObject var profileModel: ProfileModel
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -48,12 +48,12 @@ extension TrophyCollectionView {
     @ViewBuilder
     var trophyCollection: some View {
         VStack(spacing: 31) {
-            ForEach(0..<healthInteractor.allBadges.count, id: \.self) { sortIndex in
+            ForEach(0..<profileModel.allBadges.count, id: \.self) { sortIndex in
                 VStack(alignment: .leading, spacing: 10) {
                     floatingBadgeInfo(at: sortIndex)
                     HStack {
-                        ForEach(0..<healthInteractor.allBadges[sortIndex].count, id: \.self) { levelIndex in
-                            let isOpened = healthInteractor.allBadges[sortIndex][levelIndex]
+                        ForEach(0..<profileModel.allBadges[sortIndex].count, id: \.self) { levelIndex in
+                            let isOpened = profileModel.allBadges[sortIndex][levelIndex]
                             
                             TrophyView(sort: sortIndex, level: levelIndex, isOpened: isOpened)
                         }
@@ -65,8 +65,8 @@ extension TrophyCollectionView {
 }
 
 #Preview {
-    @StateObject var heathInteracter = HealthInteractor.shared
+    @StateObject var profileModel = ProfileModel(healthInteractor: HealthInteractor.shared)
+    
     return TrophyCollectionView()
-        .environmentObject(heathInteracter)
+        .environmentObject(profileModel)
 }
-


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #268

## 🏃‍♂️ 구현/변경 사항
- HealthiInteractor에서 뱃지와 평균 능력치를 사용하는 뷰를 ProfileModel 부분으로 옮겼습니다. 
- HealthInteractor workouts를 불러오는 로직을 Combine을 이용해서 해서, MainView, ContentView가 많이 바뀌었습니다.
- RadarChartView 라는 곳에서 스파이더 차트를 그립니다. 

## 📷 스크린샷


## ✏️  ETC


## 🙏To Reviewer
- 하면서 RadarChartView라는 것을 만들어서 레이더 차트를 여러 곳에서 재사용할 수 있도록 수정하였는데 새로운 이슈가 발생해서 그것도 이슈로 넣겠습니다. 
관련 이슈: #276 