### PR TITLE
fix: [#288] Music Player Error Fix and Music Overlapping

### DIFF
--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/ContentView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/ContentView.swift
@@ -41,8 +41,9 @@ struct ContentView: View {
             }
             .onAppear {
                 // 음악을 틀기
-                if !soundManager.isMusicPlaying {
-                    soundManager.toggleMusic()
+                if soundManager.isMusicPlaying {
+                    print("this worked")
+                    soundManager.playBackground()
                 }
             }
         }

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/EmptyDataView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/EmptyDataView.swift
@@ -145,11 +145,6 @@ struct EmptyDataView: View {
                 
                 Spacer()
             }
-            .onAppear {
-                if !soundManager.isMusicPlaying {
-                    soundManager.toggleMusic()
-                }
-            }
         .padding(.horizontal)
         .navigationTitle("")
     }

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
@@ -177,11 +177,6 @@ struct MainView: View {
                 
                 AnalyticsView()
             }
-            .onAppear {
-                if !soundManager.isMusicPlaying {
-                    soundManager.toggleMusic()
-                }
-            }
         }
         .refreshable {
             healthInteractor.requestAuthorization()

--- a/SoccerBeat/SoccerBeat/Sources/Features/SoundEffect/SoundManager.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/SoundEffect/SoundManager.swift
@@ -14,9 +14,11 @@ final class SoundManager: ObservableObject {
     private var cardBackPlayer: AVAudioPlayer?
     private var photoSelectPlayer: AVAudioPlayer?
     
-    @Published var isMusicPlaying = true
+    @Published var isMusicPlaying: Bool
     
     init() {
+        isMusicPlaying = UserDefaults.standard.bool(forKey: "isMusicPlaying")
+        print("musicPlaying? ", isMusicPlaying)
         setupPlayer()
     }
     
@@ -32,6 +34,11 @@ final class SoundManager: ObservableObject {
         
         // 음악 파일 별로 플레이어 할당
         do {
+            
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.ambient, mode: .default)
+            try session.setActive(true)
+            
             backgroundPlayer = try AVAudioPlayer(contentsOf: backgroundURL)
             cardFrontPlayer = try AVAudioPlayer(contentsOf: cardEffectURL)
             cardBackPlayer = try AVAudioPlayer(contentsOf: cardEffectURL)
@@ -41,7 +48,7 @@ final class SoundManager: ObservableObject {
         }
         
         // 상태 불러와서 저장
-        self.isMusicPlaying = UserDefaults.standard.bool(forKey: "isMusicPlaying")
+        
     }
     
     func playBackground() {

--- a/SoccerBeat/SoccerBeat/Sources/Features/SoundEffect/SoundManager.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/SoundEffect/SoundManager.swift
@@ -40,6 +40,7 @@ final class SoundManager: ObservableObject {
             try session.setActive(true)
             
             backgroundPlayer = try AVAudioPlayer(contentsOf: backgroundURL)
+            backgroundPlayer?.volume = 0.5
             cardFrontPlayer = try AVAudioPlayer(contentsOf: cardEffectURL)
             cardBackPlayer = try AVAudioPlayer(contentsOf: cardEffectURL)
             photoSelectPlayer = try AVAudioPlayer(contentsOf: photoSelectEffectURL)


### PR DESCRIPTION
## 🐲 관련 이슈
close #288 

## 🏃‍♂️ 구현/변경 사항
- 음악 재생을 contentView에서 관리합니다.
- 오디오 세션을 만들어서 음악들이 중첩될 수 있도록 했습니다.

## 📷 스크린샷
![musicplayerrorfix](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/52576276/9e692528-7a9c-4e7f-9e98-70dcbef32545)

## ✏️  ETC
영상 보시면 기존 재생 음악을 끊기지 않고 그 위에 재생되는 것 + 유저 디폴트로 설정값 잘 들어오는 것을 확인할 수 있었어요! 기존코드에도 유저 디폴트로 고정되어 있었는데 (아마 밤새는 기간에 썼던 코드여서 그런지 ㅠㅠ) 재생이 안되어있을 경우 재생하도록 이상하게 코드가 짜여있던 부분 있었습니다. 제거했습니다.!
