### PR TITLE
feat: [#292] 경기 데이터 배열이 빈 값일 때 보여주는 UI를 SkeletonUI를 이용해서 수정

### DIFF
--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		BE010D3D2B0512680093A5FE /* Double+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE010D3B2B0512680093A5FE /* Double+extension.swift */; };
 		BE0639D82AE61BC2008D1D4E /* SplitControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0639D72AE61BC2008D1D4E /* SplitControlsView.swift */; };
 		BE0639DA2AE66D93008D1D4E /* SessionPagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0639D92AE66D93008D1D4E /* SessionPagingView.swift */; };
+		BE0AF4EF2BC7AA3C00D4FDF2 /* SkeletonUI in Frameworks */ = {isa = PBXBuildFile; productRef = BE0AF4EE2BC7AA3C00D4FDF2 /* SkeletonUI */; };
+		BE0AF4F12BC7AA4500D4FDF2 /* SkeletonUI in Frameworks */ = {isa = PBXBuildFile; productRef = BE0AF4F02BC7AA4500D4FDF2 /* SkeletonUI */; };
 		BE16B7C32B0B7D0300192C3B /* TrophyCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE16B7C22B0B7D0300192C3B /* TrophyCollectionView.swift */; };
 		BE22D6352AE586AA009035C9 /* GameProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE22D6302AE586AA009035C9 /* GameProgressView.swift */; };
 		BE22D6372AE586AA009035C9 /* SprintStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE22D6322AE586AA009035C9 /* SprintStatusView.swift */; };
@@ -110,7 +112,6 @@
 		BEDE52422B04D69400BBFD94 /* SF-Pro-Text-SemiboldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = BEDE52412B04D69400BBFD94 /* SF-Pro-Text-SemiboldItalic.otf */; };
 		BEDE52432B04D69400BBFD94 /* SF-Pro-Text-SemiboldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = BEDE52412B04D69400BBFD94 /* SF-Pro-Text-SemiboldItalic.otf */; };
 		D30F0B4C2AF0F19D002965D6 /* HeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F0B4B2AF0F19D002965D6 /* HeatmapView.swift */; };
-		D31B4ABE2B0AF35B00DD9100 /* EmptyDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31B4ABD2B0AF35B00DD9100 /* EmptyDataView.swift */; };
 		D31B4AC02B0B819000DD9100 /* DataConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31B4ABF2B0B819000DD9100 /* DataConverter.swift */; };
 		D37F6ABC2B0CDFAC00A37E4F /* HealthAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37F6ABB2B0CDFAC00A37E4F /* HealthAlertView.swift */; };
 		D3A1F10F2B067E8F00EB2049 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1F10E2B067E8F00EB2049 /* MainView.swift */; };
@@ -247,7 +248,6 @@
 		BEDE523D2B03BFF800BBFD94 /* Analyzable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analyzable.swift; sourceTree = "<group>"; };
 		BEDE52412B04D69400BBFD94 /* SF-Pro-Text-SemiboldItalic.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Text-SemiboldItalic.otf"; sourceTree = "<group>"; };
 		D30F0B4B2AF0F19D002965D6 /* HeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapView.swift; sourceTree = "<group>"; };
-		D31B4ABD2B0AF35B00DD9100 /* EmptyDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyDataView.swift; sourceTree = "<group>"; };
 		D31B4ABF2B0B819000DD9100 /* DataConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataConverter.swift; sourceTree = "<group>"; };
 		D37F6ABB2B0CDFAC00A37E4F /* HealthAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAlertView.swift; sourceTree = "<group>"; };
 		D3A1F10E2B067E8F00EB2049 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -285,6 +285,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE0AF4EF2BC7AA3C00D4FDF2 /* SkeletonUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -292,6 +293,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE0AF4F12BC7AA4500D4FDF2 /* SkeletonUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -344,6 +346,13 @@
 				D3C500162AE36F3F00EFAEFF /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		BE0AF4ED2BC7AA3C00D4FDF2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		BE22D62F2AE586AA009035C9 /* Progress */ = {
@@ -411,6 +420,7 @@
 				D3C500232AE36F3F00EFAEFF /* SoccerBeat Watch App */,
 				685D7B582AE38D1A00783433 /* .swiftlint.yml */,
 				D3C500102AE36F3F00EFAEFF /* Products */,
+				BE0AF4ED2BC7AA3C00D4FDF2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -516,7 +526,6 @@
 				FB954B012BB2F92200A365FB /* Subviews */,
 				D3C500142AE36F3F00EFAEFF /* ContentView.swift */,
 				D3A1F10E2B067E8F00EB2049 /* MainView.swift */,
-				D31B4ABD2B0AF35B00DD9100 /* EmptyDataView.swift */,
 			);
 			path = HomeView;
 			sourceTree = "<group>";
@@ -759,6 +768,9 @@
 				D3C500222AE36F3F00EFAEFF /* PBXTargetDependency */,
 			);
 			name = SoccerBeat;
+			packageProductDependencies = (
+				BE0AF4EE2BC7AA3C00D4FDF2 /* SkeletonUI */,
+			);
 			productName = SoccerBeat;
 			productReference = D3C5000F2AE36F3F00EFAEFF /* SoccerBeat.app */;
 			productType = "com.apple.product-type.application";
@@ -777,6 +789,9 @@
 			dependencies = (
 			);
 			name = "SoccerBeat Watch App";
+			packageProductDependencies = (
+				BE0AF4F02BC7AA4500D4FDF2 /* SkeletonUI */,
+			);
 			productName = "SoccerBeat Watch App";
 			productReference = D3C5001F2AE36F3F00EFAEFF /* SoccerBeat Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -809,6 +824,9 @@
 				ko,
 			);
 			mainGroup = D3C500062AE36F3E00EFAEFF;
+			packageReferences = (
+				BE4982B32BC7A74F003208E3 /* XCRemoteSwiftPackageReference "SkeletonUI" */,
+			);
 			productRefGroup = D3C500102AE36F3F00EFAEFF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -975,7 +993,6 @@
 				BE4069E22AF279F600FA3030 /* Font+extension.swift in Sources */,
 				D30F0B4C2AF0F19D002965D6 /* HeatmapView.swift in Sources */,
 				682A69602BC406AB00E8EABC /* NoAuthorizationView.swift in Sources */,
-				D31B4ABE2B0AF35B00DD9100 /* EmptyDataView.swift in Sources */,
 				685D7B752AE53DC400783433 /* SpeedChart.swift in Sources */,
 				D3D4F18D2AF26662006C6B8A /* WorkoutData.swift in Sources */,
 				D3A1F10F2B067E8F00EB2049 /* MainView.swift in Sources */,
@@ -1377,6 +1394,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BE4982B32BC7A74F003208E3 /* XCRemoteSwiftPackageReference "SkeletonUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CSolanaM/SkeletonUI.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BE0AF4EE2BC7AA3C00D4FDF2 /* SkeletonUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BE4982B32BC7A74F003208E3 /* XCRemoteSwiftPackageReference "SkeletonUI" */;
+			productName = SkeletonUI;
+		};
+		BE0AF4F02BC7AA4500D4FDF2 /* SkeletonUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BE4982B32BC7A74F003208E3 /* XCRemoteSwiftPackageReference "SkeletonUI" */;
+			productName = SkeletonUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D3C500072AE36F3E00EFAEFF /* Project object */;
 }

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "skeletonui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CSolanaM/SkeletonUI.git",
+      "state" : {
+        "revision" : "d5c8a4f62be6a631bd4fe1922505eb34e82e5b4e",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
+        "version" : "1.16.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/SoccerBeat/SoccerBeat/SoccerBeatApp.swift
+++ b/SoccerBeat/SoccerBeat/SoccerBeatApp.swift
@@ -39,6 +39,11 @@ struct SoccerBeatApp: App {
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                 noHealth = healthInteracter.haveNoHealthAuthorization()
                 noLocation = healthInteracter.haveNoLocationAuthorization()
+                Task {
+                    if !noHealth && !noLocation {
+                        await self.healthInteracter.fetchWorkoutData()
+                    }
+                }
             }
         }
     }

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/ContentView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by daaan on 10/21/23.
 //
 
+import SkeletonUI
 import SwiftUI
 import HealthKit
 
@@ -24,11 +25,7 @@ struct ContentView: View {
                 if healthAlert {
                     HealthAlertView(showingAlert: $healthAlert)
                 } else {
-                    if workouts.isEmpty {
-                        EmptyDataView()
-                    } else {
-                        MainView(workouts: $workouts)
-                    }
+                    MainView(workouts: $workouts)
                 }
             }
             .task {

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/EmptyDataView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/EmptyDataView.swift
@@ -13,7 +13,7 @@ struct EmptyDataView: View {
     @EnvironmentObject var profileModel: ProfileModel
     
     @State var isShowingBug = false
-    let alertTitle: String = "문제가 있으신가요?"
+    let alertTitle = "문제가 있으신가요?"
     
     var body: some View {
             VStack(spacing: 0.0) {

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
@@ -74,35 +74,45 @@ struct MainView: View {
                 
                 HStack(alignment: .bottom) {
                     VStack(alignment: .leading) {
-                        Text(workouts[0].yearMonthDay)
-                            .font(.mainSubTitleText)
-                            .opacity(0.7)
+                        if !workouts.isEmpty {
+                            Text(workouts[0].yearMonthDay)
+                                .font(.mainSubTitleText)
+                                .opacity(0.7)
+                        }
                         Text("최근 경기")
                             .font(.mainTitleText)
+                            .skeleton(with: workouts.isEmpty)
                     }
+                    
+                    
                     Spacer()
                     NavigationLink {
                         ProfileView()
                     } label: {
                         CardFront(degree: .constant(0), width: 72, height: 110)
+                            .skeleton(with: workouts.isEmpty)
                     }
                 }
                 .padding()
                 
                 NavigationLink {
-                    MatchDetailView(workoutData: workouts[0])
+                    if !workouts.isEmpty {
+                        MatchDetailView(workoutData: workouts[0])
+                    }
                 } label: {
                     ZStack {
                         LightRectangleView(alpha: 0.6, color: .black, radius: 15)
                         HStack {
                             VStack {
                                 HStack {
-                                    let recent = DataConverter.toLevels(workouts[0])
-                                    let average = DataConverter.toLevels(profileModel.averageAbility)
-                                    
-                                    ViewControllerContainer(RadarViewController(radarAverageValue: average, radarAtypicalValue: recent))                              .scaleEffect(CGSize(width: 0.7, height: 0.7))
-                                        .fixedSize()
-                                        .frame(width: 210, height: 210)
+                                    if !workouts.isEmpty {
+                                        let recent = DataConverter.toLevels(workouts[0])
+                                        let average = DataConverter.toLevels(profileModel.averageAbility)
+                                        
+                                        ViewControllerContainer(RadarViewController(radarAverageValue: average, radarAtypicalValue: recent))                              .scaleEffect(CGSize(width: 0.7, height: 0.7))
+                                                                                .fixedSize()
+                                                                                .frame(width: 210, height: 210)
+                                    }
                                     
                                     Spacer()
                                     
@@ -112,14 +122,20 @@ struct MainView: View {
                                         VStack(alignment: .leading) {
                                             Text(currentLocation)
                                                 .font(.mainDateLocation)
+                                                .skeleton(with: workouts.isEmpty)
                                                 .foregroundStyle(.mainDateTime)
                                                 .opacity(0.8)
                                                 .task {
-                                                    currentLocation = await workouts[0].location
+                                                    if !workouts.isEmpty {
+                                                        currentLocation = await workouts[0].location
+                                                    }
                                                 }
                                             Group {
                                                 Text("경기 시간")
-                                                Text(workouts[0].time)
+                                                    .skeleton(with: workouts.isEmpty)
+                                                if !workouts.isEmpty {
+                                                    Text(workouts[0].time)
+                                                }
                                             }
                                             .font(.mainTime)
                                             .foregroundStyle(.mainMatchTime)
@@ -129,15 +145,17 @@ struct MainView: View {
                                         
                                         // 뱃지
                                         HStack {
-                                            ForEach(workouts[0].matchBadge.indices, id: \.self) { index in
-                                                if let badgeName = ShortenedBadgeImageDictionary[index][workouts[0].matchBadge[index]] {
-                                                    if badgeName.isEmpty {
-                                                        EmptyView()
-                                                    } else {
-                                                        Image(badgeName)
-                                                            .resizable()
-                                                            .aspectRatio(contentMode: .fit)
-                                                            .frame(width: 32, height: 36)
+                                            if !workouts.isEmpty {
+                                                ForEach(workouts[0].matchBadge.indices, id: \.self) { index in
+                                                    if let badgeName = ShortenedBadgeImageDictionary[index][workouts[0].matchBadge[index]] {
+                                                        if badgeName.isEmpty {
+                                                            EmptyView()
+                                                        } else {
+                                                            Image(badgeName)
+                                                                .resizable()
+                                                                .aspectRatio(contentMode: .fit)
+                                                                .frame(width: 32, height: 36)
+                                                        }
                                                     }
                                                 }
                                             }
@@ -165,6 +183,7 @@ struct MainView: View {
                             
                             Spacer()
                         }
+                        .skeleton(with: workouts.isEmpty)
                         .padding()
                     }
                 }
@@ -173,6 +192,7 @@ struct MainView: View {
                     .frame(height: 80)
                 
                 AnalyticsView()
+                    .skeleton(with: workouts.isEmpty)
             }
         }
         .refreshable {


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #292 

## 🏃‍♂️ 구현/변경 사항
- 스켈레톤 UI를 이용해서 경기 데이터 배열이 비어있을 때를 표현해봤습니다. 
- `MainView`에서 out of index 에러가 날 만한 부분을 에러 처리 하였습니다. 
- Swift Pakage Manager를 이용해서 [SkeletonUI](https://github.com/CSolanaM/SkeletonUI) 패키지를 추가하였습니다. 

## 📷 스크린샷

https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/7031a9cd-53ec-4c91-8aa4-e6f3fd38e894



## ✏️  ETC


## 🙏To Reviewer
