### PR TITLE
feat: [#295] 추세 차트 횡스크롤 구현

### DIFF
--- a/SoccerBeat/Common/BackportView+extension.swift
+++ b/SoccerBeat/Common/BackportView+extension.swift
@@ -1,0 +1,8 @@
+//
+//  BackportView+extension.swift
+//  SoccerBeat
+//
+//  Created by Hyungmin Kim on 4/15/24.
+//
+
+import swiftUI

--- a/SoccerBeat/Common/Data/WorkoutData.swift
+++ b/SoccerBeat/Common/Data/WorkoutData.swift
@@ -120,7 +120,13 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
         WorkoutData(dataID: 5, date: "2023-10-20T01:20:32Z", time: "60:10", distance: 4.5, sprint: 11, velocity: 17.2, acceleration: 3.0, heartRate: ["max": 175, "min": 60], route: [], center: [0, 0]),
         WorkoutData(dataID: 6, date: "2023-10-21T01:20:32Z", time: "60:10", distance: 3.6, sprint: 5, velocity: 24.4, acceleration: 3.0, heartRate: ["max": 190, "min": 79], route: [], center: [0, 0]),
         WorkoutData(dataID: 7, date: "2023-10-23T01:20:32Z", time: "60:10", distance: 3.8, sprint: 13, velocity: 15.9, acceleration: 3.0, heartRate: ["max": 183, "min": 91], route: [], center: [0, 0]),
-        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.9, sprint: 17, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 169, "min": 79], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.5, sprint: 17, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 159, "min": 69], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.1, sprint: 1, velocity: 17.3, acceleration: 3.0, heartRate: ["max": 144, "min": 73], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 3.2, sprint: 7, velocity: 16.3, acceleration: 3.0, heartRate: ["max": 159, "min": 72], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 0.5, sprint: 8, velocity: 14.3, acceleration: 3.0, heartRate: ["max": 162, "min": 63], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 1.9, sprint: 9, velocity: 12.3, acceleration: 3.0, heartRate: ["max": 168, "min": 59], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 4.9, sprint: 10, velocity: 13.3, acceleration: 3.0, heartRate: ["max": 171, "min": 68], route: [], center: [0, 0]),
+        WorkoutData(dataID: 8, date: "2023-10-24T01:20:32Z", time: "60:10", distance: 2.9, sprint: 17, velocity: 11.3, acceleration: 3.0, heartRate: ["max": 158, "min": 69], route: [], center: [0, 0]),
         WorkoutData(dataID: 9, date: "2023-10-27T01:20:32Z", time: "60:10", distance: 5.3, sprint: 12, velocity: 23.5, acceleration: 3.0, heartRate: ["max": 187, "min": 60], route: [], center: [0, 0])
     ]
     

--- a/SoccerBeat/Common/Utiles/Backport+extension.swift
+++ b/SoccerBeat/Common/Utiles/Backport+extension.swift
@@ -1,0 +1,30 @@
+//
+//  Backport+extension.swift
+//  SoccerBeat
+//
+//  Created by Hyungmin Kim on 4/15/24.
+//
+
+import SwiftUI
+
+public struct Backport<Content> {
+    public let content: Content
+
+    public init(_ content: Content) {
+        self.content = content
+    }
+}
+
+extension View {
+    var backport: Backport<Self> { Backport(self) }
+}
+
+extension Backport where Content: View {
+    @ViewBuilder func defaultScrollAnchor(_ anchor: UnitPoint?) -> some View {
+        if #available(iOS 17, *) {
+            content.defaultScrollAnchor(anchor)
+        } else {
+            content
+        }
+    }
+}

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		FB2EC9C62B0B527F0050B0E8 /* SF-Pro-Text-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = FB2EC9C52B0B527F0050B0E8 /* SF-Pro-Text-Bold.otf */; };
 		FB2EC9C72B0B527F0050B0E8 /* SF-Pro-Text-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = FB2EC9C52B0B527F0050B0E8 /* SF-Pro-Text-Bold.otf */; };
 		FB5859972B14F0A2002617E0 /* InformationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5859962B14F0A2002617E0 /* InformationButton.swift */; };
+		FB61FFB32BCD518800EF0D1B /* Backport+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB61FFB22BCD518800EF0D1B /* Backport+extension.swift */; };
 		FB954AFF2BB2BAAF00A365FB /* HealthInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D4F1892AF248CE006C6B8A /* HealthInteractor.swift */; };
 		FBA3DA622B00E6EF0025AD7B /* ShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA3DA612B00E6EF0025AD7B /* ShareView.swift */; };
 		FBA3DA812B03B5770025AD7B /* SF-Pro-Display-HeavyItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = FBA3DA802B03B5770025AD7B /* SF-Pro-Display-HeavyItalic.otf */; };
@@ -270,6 +271,7 @@
 		FB2EC9C22B0B50BB0050B0E8 /* BadgeImageDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeImageDictionary.swift; sourceTree = "<group>"; };
 		FB2EC9C52B0B527F0050B0E8 /* SF-Pro-Text-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Text-Bold.otf"; sourceTree = "<group>"; };
 		FB5859962B14F0A2002617E0 /* InformationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationButton.swift; sourceTree = "<group>"; };
+		FB61FFB22BCD518800EF0D1B /* Backport+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Backport+extension.swift"; sourceTree = "<group>"; };
 		FBA3DA612B00E6EF0025AD7B /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
 		FBA3DA802B03B5770025AD7B /* SF-Pro-Display-HeavyItalic.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Display-HeavyItalic.otf"; sourceTree = "<group>"; };
 		FBA3DA862B03B9F20025AD7B /* SF-Pro-Display-RegularItalic.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro-Display-RegularItalic.otf"; sourceTree = "<group>"; };
@@ -377,6 +379,7 @@
 				BE40699E2AF0F2F500FA3030 /* Bundle+extension.swift */,
 				BE010D3B2B0512680093A5FE /* Double+extension.swift */,
 				6851E6E22B0C8E7F007D1DD8 /* Text+extension.swift */,
+				FB61FFB22BCD518800EF0D1B /* Backport+extension.swift */,
 			);
 			name = Extensions;
 			path = Utiles;
@@ -953,6 +956,7 @@
 				D3C500132AE36F3F00EFAEFF /* SoccerBeatApp.swift in Sources */,
 				BE4A91582B011C8B004AAFA3 /* SprintChart.swift in Sources */,
 				D3A1F1112B06847600EB2049 /* ProfileView.swift in Sources */,
+				FB61FFB32BCD518800EF0D1B /* Backport+extension.swift in Sources */,
 				FBCED9322AE4218E00C57BF9 /* MatchRecapView.swift in Sources */,
 				BE010D392B0511CC0093A5FE /* FloatingCapsuleModifier.swift in Sources */,
 				BECCFAB82B066B38009F4BE5 /* SprintChartOverview.swift in Sources */,

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
@@ -38,7 +38,6 @@ struct MainView: View {
                         }
                     }
                     .foregroundStyle(.white)
-                    .padding(.top, 5)
                     Spacer()
                     
                     Button(action: { isShowingBug.toggle() } ) {
@@ -52,7 +51,6 @@ struct MainView: View {
                             .stroke(lineWidth: 0.8)
                             .frame(height: 24)
                     }
-                    .padding(.top, 5)
                     .alert(
                         alertTitle,
                         isPresented: $isShowingBug
@@ -71,6 +69,7 @@ struct MainView: View {
                     }
                 }
                 .padding(.horizontal)
+                .padding(.top, 5)
                 
                 HStack(alignment: .bottom) {
                     VStack(alignment: .leading) {

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
@@ -52,23 +52,23 @@ struct MainView: View {
                             .stroke(lineWidth: 0.8)
                             .frame(height: 24)
                     }
-                    .padding(.horizontal)
+                    .padding(.top, 5)
                     .alert(
-                                alertTitle,
-                                isPresented: $isShowingBug
-                            ) {
-                                Button("취소", role: .cancel) {
-                                    // Handle the acknowledgement.
-                                    isShowingBug.toggle()
-                                }
-                                Button("문의하기") {
-                                    let url = createEmailUrl(to: "guryongpo23@gmail.com", subject: "", body: "")
-                                    openURL(urlString: url)
-                                    // TODO: 로그인 안될 때엔 어떻게 됩니까?
-                                }
-                            } message: {
-                               Text("불편을 드려 죄송합니다. \n\nSoccerBeat의 개발자 계정으로 문의를 주시면 빠른 시일 안에 답변드리겠습니다. ")
-                            }
+                        alertTitle,
+                        isPresented: $isShowingBug
+                    ) {
+                        Button("취소", role: .cancel) {
+                            // Handle the acknowledgement.
+                            isShowingBug.toggle()
+                        }
+                        Button("문의하기") {
+                            let url = createEmailUrl(to: "guryongpo23@gmail.com", subject: "", body: "")
+                            openURL(urlString: url)
+                            // TODO: 로그인 안될 때엔 어떻게 됩니까?
+                        }
+                    } message: {
+                        Text("불편을 드려 죄송합니다. \n\nSoccerBeat의 개발자 계정으로 문의를 주시면 빠른 시일 안에 답변드리겠습니다. ")
+                    }
                 }
                 .padding(.horizontal)
                 
@@ -101,8 +101,8 @@ struct MainView: View {
                                     let average = DataConverter.toLevels(profileModel.averageAbility)
                                     
                                     ViewControllerContainer(RadarViewController(radarAverageValue: average, radarAtypicalValue: recent))                              .scaleEffect(CGSize(width: 0.7, height: 0.7))
-                                        .fixedSize()
-                                        .frame(width: 210, height: 210)
+                                                                            .fixedSize()
+                                                                            .frame(width: 210, height: 210)
                                     
                                     Spacer()
                                     
@@ -192,16 +192,16 @@ struct MainView: View {
             }
         }
     }
-
+    
     func createEmailUrl(to: String, subject: String, body: String) -> String {
         let subjectEncoded = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         let bodyEncoded = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-            
+        
         let defaultUrl = "mailto:\(to)?subject=\(subjectEncoded)&body=\(bodyEncoded)"
-            
+        
         return defaultUrl
     }
-
+    
 }
 
 #Preview {

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/BPMChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/BPMChart.swift
@@ -58,7 +58,7 @@ struct BPMChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageBPM: Double
-    let betweenBarSpace: CGFloat = 70
+    let betweenBarSpace = 70.0
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -69,94 +69,49 @@ struct BPMChart: View {
     }
     
     var body: some View {
-        if #available(iOS 17.0, *) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("HeartRate", 0),
-                            yEnd: .value("HeartRate", workout.maxHeartRate)
-                        )
-                        .foregroundStyle(isMax(workout) ? .bpmMax
-                                         : (isMin(workout) ? .bpmMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.maxHeartRate.formatted() + "Bpm")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
+        ScrollView(.horizontal, showsIndicators: false) {
+            Chart {
+                ForEach(0..<workouts.count, id: \.self) { index in
+                    let workout = workouts[index]
+                    
+                    BarMark(
+                        x: .value("Order", index),
+                        yStart: .value("HeartRate", 0),
+                        yEnd: .value("HeartRate", workout.maxHeartRate)
+                    )
+                    .foregroundStyle(isMax(workout) ? .bpmMax
+                                     : (isMin(workout) ? .bpmMin : .chartDefault))
+                    .cornerRadius(300, style: .continuous)
+                    // MARK: - Bar Chart Data, value 표시
+                    // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                    .annotation(position: .bottom, alignment: .center) {
+                        let isMaxOrMin = isMin(workout) || isMax(workout)
+                        VStack(spacing: 6) {
+                            Text(workout.maxHeartRate.formatted() + "Bpm")
+                                .font(.maxValueUint)
+                                .foregroundStyle(.maxValueStyle)
+                                .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                .padding(.top, 8)
+                            
+                            Text("\(workout.day)일")
+                                .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                .foregroundStyle(.defaultDayStyle)
                         }
-                        
                     }
+                    
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
-            .defaultScrollAnchor(.trailing)
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("HeartRate", 0),
-                            yEnd: .value("HeartRate", workout.maxHeartRate)
-                        )
-                        .foregroundStyle(isMax(workout) ? .bpmMax
-                                         : (isMin(workout) ? .bpmMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.maxHeartRate.formatted() + "Bpm")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
-                        }
-                        
-                    }
+            // MARK: - 가장 밑에 일자 표시, 자리잡기용
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day)) { _ in
+                    AxisValueLabel(format: .dateTime.day(), centered: true)
+                        .font(.defaultDayUnit)
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
+            .chartYAxis(.hidden)
+            .frame(width: CGFloat(workouts.count) * betweenBarSpace)
         }
+        .backport.defaultScrollAnchor(.trailing)
     }
 }
 
@@ -223,8 +178,8 @@ extension BPMChartView {
             .overlay {
                 VStack(spacing: 4) {
                     Text("해리 케인의 평소 심박수는 40bpm 입니다.")
-                    .font(.playerComapareSaying)
-                    .foregroundStyle(.playerCompareStyle)
+                        .font(.playerComapareSaying)
+                        .foregroundStyle(.playerCompareStyle)
                     Spacer()
                     Text("최근 경기 평균")
                         .font(.averageText)

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/BPMChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/BPMChart.swift
@@ -58,6 +58,7 @@ struct BPMChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageBPM: Double
+    let betweenBarSpace: CGFloat = 70
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -68,45 +69,94 @@ struct BPMChart: View {
     }
     
     var body: some View {
-        Chart {
-            ForEach(0..<workouts.count, id: \.self) { index in
-                let workout = workouts[index]
-                
-                BarMark(
-                    x: .value("Order", index),
-                    yStart: .value("HeartRate", 0),
-                    yEnd: .value("HeartRate", workout.maxHeartRate)
-                )
-                .foregroundStyle(isMax(workout) ? .bpmMax
-                                 : (isMin(workout) ? .bpmMin : .chartDefault))
-                .cornerRadius(300, style: .continuous)
-                // MARK: - Bar Chart Data, value 표시
-                // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                .annotation(position: .bottom, alignment: .center) {
-                    let isMaxOrMin = isMin(workout) || isMax(workout)
-                    VStack(spacing: 6) {
-                        Text(isMaxOrMin ? workout.maxHeartRate.formatted() + "Bpm" : "000Bpm" )
-                            .font(.maxValueUint)
-                            .foregroundStyle(.maxValueStyle)
-                            .opacity(isMaxOrMin ? 1.0 : 0.0)
-                            .padding(.top, 8)
+        if #available(iOS 17.0, *) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
                         
-                        Text("\(workout.day)일")
-                            .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                            .foregroundStyle(.defaultDayStyle)
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("HeartRate", 0),
+                            yEnd: .value("HeartRate", workout.maxHeartRate)
+                        )
+                        .foregroundStyle(isMax(workout) ? .bpmMax
+                                         : (isMin(workout) ? .bpmMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.maxHeartRate.formatted() + "Bpm")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
+                        
                     }
                 }
-                
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
+            }
+            .defaultScrollAnchor(.trailing)
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
+                        
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("HeartRate", 0),
+                            yEnd: .value("HeartRate", workout.maxHeartRate)
+                        )
+                        .foregroundStyle(isMax(workout) ? .bpmMax
+                                         : (isMin(workout) ? .bpmMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.maxHeartRate.formatted() + "Bpm")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
+                        
+                    }
+                }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
         }
-        // MARK: - 가장 밑에 일자 표시, 자리잡기용
-        .chartXAxis {
-            AxisMarks(values: .stride(by: .day)) { _ in
-                AxisValueLabel(format: .dateTime.day(), centered: true)
-                    .font(.defaultDayUnit)
-            }
-        }
-        .chartYAxis(.hidden)
     }
 }
 

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
@@ -59,6 +59,7 @@ struct DistanceChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageDistance: Double
+    let betweenBarSpace: CGFloat = 65
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -69,44 +70,94 @@ struct DistanceChart: View {
     }
     
     var body: some View {
-        Chart {
-            ForEach(0..<workouts.count, id: \.self) { index in
-                let workout = workouts[index]
-                
-                BarMark(
-                    x: .value("Order", index),
-                    yStart: .value("Distance", 0.0),
-                    yEnd: .value("Distance", workout.distance)
-                )
-                .foregroundStyle(isMax(workout) ? .distanceMax
-                                 : (isMin(workout) ? .distanceMin : .chartDefault))
-                .cornerRadius(300, style: .continuous)
-                // MARK: - Bar Chart Data, value 표시
-                // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                .annotation(position: .bottom, alignment: .center) {
-                    let isMaxOrMin = isMin(workout) || isMax(workout)
-                    VStack(spacing: 6) {
-                        Text(isMaxOrMin ? workout.distance.rounded() + "km" : "00km" )
-                            .font(.maxValueUint)
-                            .foregroundStyle(.maxValueStyle)
-                            .opacity(isMaxOrMin ? 1.0 : 0.0)
-                            .padding(.top, 8)
+        if #available(iOS 17.0, *) {
+            ScrollView(.horizontal) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
                         
-                        Text("\(workout.day)일")
-                            .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                            .foregroundStyle(.defaultDayStyle)
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("Distance", 0.0),
+                            yEnd: .value("Distance", workout.distance)
+                        )
+                        .foregroundStyle(isMax(workout) ? .distanceMax
+                                         : (isMin(workout) ? .distanceMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.distance.rounded() + "km")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
                     }
                 }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
-        }
-        // MARK: - 가장 밑에 일자 표시, 자리잡기용
-        .chartXAxis {
-            AxisMarks(values: .stride(by: .day)) { _ in
-                AxisValueLabel(format: .dateTime.day(), centered: true)
-                    .font(.defaultDayUnit)
+            .defaultScrollAnchor(.trailing)
+            .scrollIndicators(.never)
+        } else {
+            ScrollView(.horizontal) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
+                        
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("Distance", 0.0),
+                            yEnd: .value("Distance", workout.distance)
+                        )
+                        .foregroundStyle(isMax(workout) ? .distanceMax
+                                         : (isMin(workout) ? .distanceMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.distance.rounded() + "km")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
+                    }
+                }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
+            .scrollIndicators(.never)
         }
-        .chartYAxis(.hidden)
     }
 }
 
@@ -193,3 +244,4 @@ extension DistanceChartView {
         DistanceChartView(workouts: WorkoutData.exampleWorkouts)
     }
 }
+

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
@@ -59,7 +59,7 @@ struct DistanceChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageDistance: Double
-    let betweenBarSpace: CGFloat = 65
+    let betweenBarSpace: CGFloat = 70
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -71,7 +71,7 @@ struct DistanceChart: View {
     
     var body: some View {
         if #available(iOS 17.0, *) {
-            ScrollView(.horizontal) {
+            ScrollView(.horizontal, showsIndicators: false) {
                 Chart {
                     ForEach(0..<workouts.count, id: \.self) { index in
                         let workout = workouts[index]
@@ -113,9 +113,8 @@ struct DistanceChart: View {
                 .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
             .defaultScrollAnchor(.trailing)
-            .scrollIndicators(.never)
         } else {
-            ScrollView(.horizontal) {
+            ScrollView(.horizontal, showsIndicators: false) {
                 Chart {
                     ForEach(0..<workouts.count, id: \.self) { index in
                         let workout = workouts[index]
@@ -156,7 +155,6 @@ struct DistanceChart: View {
                 .chartYAxis(.hidden)
                 .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
-            .scrollIndicators(.never)
         }
     }
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
@@ -59,7 +59,7 @@ struct DistanceChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageDistance: Double
-    let betweenBarSpace: CGFloat = 70
+    let betweenBarSpace = 70.0
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -70,92 +70,48 @@ struct DistanceChart: View {
     }
     
     var body: some View {
-        if #available(iOS 17.0, *) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("Distance", 0.0),
-                            yEnd: .value("Distance", workout.distance)
-                        )
-                        .foregroundStyle(isMax(workout) ? .distanceMax
-                                         : (isMin(workout) ? .distanceMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.distance.rounded() + "km")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
+        ScrollView(.horizontal, showsIndicators: false) {
+            Chart {
+                ForEach(0..<workouts.count, id: \.self) { index in
+                    let workout = workouts[index]
+                    
+                    BarMark(
+                        x: .value("Order", index),
+                        yStart: .value("Distance", 0.0),
+                        yEnd: .value("Distance", workout.distance)
+                    )
+                    .foregroundStyle(isMax(workout) ? .distanceMax
+                                     : (isMin(workout) ? .distanceMin : .chartDefault))
+                    .cornerRadius(300, style: .continuous)
+                    // MARK: - Bar Chart Data, value 표시
+                    // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                    .annotation(position: .bottom, alignment: .center) {
+                        let isMaxOrMin = isMin(workout) || isMax(workout)
+                        VStack(spacing: 6) {
+                            Text(workout.distance.rounded() + "km")
+                                .font(.maxValueUint)
+                                .foregroundStyle(.maxValueStyle)
+                                .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                .padding(.top, 8)
+                            
+                            Text("\(workout.day)일")
+                                .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                .foregroundStyle(.defaultDayStyle)
                         }
                     }
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
-            .defaultScrollAnchor(.trailing)
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("Distance", 0.0),
-                            yEnd: .value("Distance", workout.distance)
-                        )
-                        .foregroundStyle(isMax(workout) ? .distanceMax
-                                         : (isMin(workout) ? .distanceMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.distance.rounded() + "km")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
-                        }
-                    }
+            // MARK: - 가장 밑에 일자 표시, 자리잡기용
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day)) { _ in
+                    AxisValueLabel(format: .dateTime.day(), centered: true)
+                        .font(.defaultDayUnit)
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
+            .chartYAxis(.hidden)
+            .frame(width: CGFloat(workouts.count) * betweenBarSpace)
         }
+        .backport.defaultScrollAnchor(.trailing)
     }
 }
 

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SpeedChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SpeedChart.swift
@@ -60,6 +60,8 @@ struct SpeedChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageSpeed: Double
+    let betweenBarSpace: CGFloat = 80
+
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -70,44 +72,92 @@ struct SpeedChart: View {
     }
     
     var body: some View {
-        Chart {
-            ForEach(0..<workouts.count, id: \.self) { index in
-                let workout = workouts[index]
-                
-                BarMark(
-                    x: .value("Order", index),
-                    yStart: .value("Velocity", 0.0),
-                    yEnd: .value("Velocity", workout.velocity)
-                )
-                .foregroundStyle(isMax(workout) ? .speedMax
-                                 : (isMin(workout) ? .speedMin : .chartDefault))
-                .cornerRadius(300, style: .continuous)
-                // MARK: - Bar Chart Data, value 표시
-                // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                .annotation(position: .bottom, alignment: .center) {
-                    let isMaxOrMin = isMin(workout) || isMax(workout)
-                    VStack(spacing: 6) {
-                        Text(isMaxOrMin ? workout.velocity.rounded() + "km/h" : "00km/h" )
-                            .font(.maxValueUint)
-                            .foregroundStyle(.maxValueStyle)
-                            .opacity(isMaxOrMin ? 1.0 : 0.0)
-                            .padding(.top, 8)
+        if #available(iOS 17.0, *) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
                         
-                        Text("\(workout.day)일")
-                            .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                            .foregroundStyle(.defaultDayStyle)
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("Velocity", 0.0),
+                            yEnd: .value("Velocity", workout.velocity)
+                        )
+                        .foregroundStyle(isMax(workout) ? .speedMax
+                                         : (isMin(workout) ? .speedMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.velocity.rounded() + " km/h")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
                     }
                 }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
+            }
+            .defaultScrollAnchor(.trailing)
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
+                        
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("Velocity", 0.0),
+                            yEnd: .value("Velocity", workout.velocity)
+                        )
+                        .foregroundStyle(isMax(workout) ? .speedMax
+                                         : (isMin(workout) ? .speedMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.velocity.rounded() + "km/h")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
+                    }
+                }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
         }
-        // MARK: - 가장 밑에 일자 표시, 자리잡기용
-        .chartXAxis {
-            AxisMarks(values: .stride(by: .day)) { _ in
-                AxisValueLabel(format: .dateTime.day(), centered: true)
-                    .font(.defaultDayUnit)
-            }
-        }
-        .chartYAxis(.hidden)
     }
 }
 

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SpeedChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SpeedChart.swift
@@ -60,8 +60,8 @@ struct SpeedChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageSpeed: Double
-    let betweenBarSpace: CGFloat = 80
-
+    let betweenBarSpace = 70.0
+    
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -72,92 +72,48 @@ struct SpeedChart: View {
     }
     
     var body: some View {
-        if #available(iOS 17.0, *) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("Velocity", 0.0),
-                            yEnd: .value("Velocity", workout.velocity)
-                        )
-                        .foregroundStyle(isMax(workout) ? .speedMax
-                                         : (isMin(workout) ? .speedMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.velocity.rounded() + " km/h")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
+        ScrollView(.horizontal, showsIndicators: false) {
+            Chart {
+                ForEach(0..<workouts.count, id: \.self) { index in
+                    let workout = workouts[index]
+                    
+                    BarMark(
+                        x: .value("Order", index),
+                        yStart: .value("Velocity", 0.0),
+                        yEnd: .value("Velocity", workout.velocity)
+                    )
+                    .foregroundStyle(isMax(workout) ? .speedMax
+                                     : (isMin(workout) ? .speedMin : .chartDefault))
+                    .cornerRadius(300, style: .continuous)
+                    // MARK: - Bar Chart Data, value 표시
+                    // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                    .annotation(position: .bottom, alignment: .center) {
+                        let isMaxOrMin = isMin(workout) || isMax(workout)
+                        VStack(spacing: 6) {
+                            Text(workout.velocity.rounded() + " km/h")
+                                .font(.maxValueUint)
+                                .foregroundStyle(.maxValueStyle)
+                                .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                .padding(.top, 8)
+                            
+                            Text("\(workout.day)일")
+                                .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                .foregroundStyle(.defaultDayStyle)
                         }
                     }
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
-            .defaultScrollAnchor(.trailing)
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("Velocity", 0.0),
-                            yEnd: .value("Velocity", workout.velocity)
-                        )
-                        .foregroundStyle(isMax(workout) ? .speedMax
-                                         : (isMin(workout) ? .speedMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.velocity.rounded() + "km/h")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
-                        }
-                    }
+            // MARK: - 가장 밑에 일자 표시, 자리잡기용
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day)) { _ in
+                    AxisValueLabel(format: .dateTime.day(), centered: true)
+                        .font(.defaultDayUnit)
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
+            .chartYAxis(.hidden)
+            .frame(width: CGFloat(workouts.count) * betweenBarSpace)
         }
+        .backport.defaultScrollAnchor(.trailing)
     }
 }
 

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
@@ -58,7 +58,7 @@ struct SprintChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageSprint: Double
-    let betweenBarSpace: CGFloat = 65
+    let betweenBarSpace: CGFloat = 70
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -69,44 +69,92 @@ struct SprintChart: View {
     }
     
     var body: some View {
-        Chart {
-            ForEach(0..<workouts.count, id: \.self) { index in
-                let workout = workouts[index]
-                
-                BarMark(
-                    x: .value("Order", index),
-                    yStart: .value("Sprint", 0),
-                    yEnd: .value("Sprint", workout.sprint)
-                )
-                .foregroundStyle(isMax(workout) ? .sprintMax
-                                 : (isMin(workout) ? .sprintMin : .chartDefault))
-                .cornerRadius(300, style: .continuous)
-                // MARK: - Bar Chart Data, value 표시
-                // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                .annotation(position: .bottom, alignment: .center) {
-                    let isMaxOrMin = isMin(workout) || isMax(workout)
-                    VStack(spacing: 6) {
-                        Text(isMaxOrMin ? workout.sprint.formatted() + "회" : "0회" )
-                            .font(.maxValueUint)
-                            .foregroundStyle(.maxValueStyle)
-                            .opacity(isMaxOrMin ? 1.0 : 0.0)
-                            .padding(.top, 8)
+        if #available(iOS 17.0, *) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
                         
-                        Text("\(workout.day)일")
-                            .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                            .foregroundStyle(.defaultDayStyle)
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("Sprint", 0),
+                            yEnd: .value("Sprint", workout.sprint)
+                        )
+                        .foregroundStyle(isMax(workout) ? .sprintMax
+                                         : (isMin(workout) ? .sprintMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.sprint.formatted() + "회")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
                     }
                 }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
+            }
+            .defaultScrollAnchor(.trailing)
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Chart {
+                    ForEach(0..<workouts.count, id: \.self) { index in
+                        let workout = workouts[index]
+                        
+                        BarMark(
+                            x: .value("Order", index),
+                            yStart: .value("Sprint", 0),
+                            yEnd: .value("Sprint", workout.sprint)
+                        )
+                        .foregroundStyle(isMax(workout) ? .sprintMax
+                                         : (isMin(workout) ? .sprintMin : .chartDefault))
+                        .cornerRadius(300, style: .continuous)
+                        // MARK: - Bar Chart Data, value 표시
+                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                        .annotation(position: .bottom, alignment: .center) {
+                            let isMaxOrMin = isMin(workout) || isMax(workout)
+                            VStack(spacing: 6) {
+                                Text(workout.sprint.formatted() + "회")
+                                    .font(.maxValueUint)
+                                    .foregroundStyle(.maxValueStyle)
+                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                    .padding(.top, 8)
+                                
+                                Text("\(workout.day)일")
+                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                    .foregroundStyle(.defaultDayStyle)
+                            }
+                        }
+                    }
+                }
+                // MARK: - 가장 밑에 일자 표시, 자리잡기용
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.day(), centered: true)
+                            .font(.defaultDayUnit)
+                    }
+                }
+                .chartYAxis(.hidden)
+                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
         }
-        // MARK: - 가장 밑에 일자 표시, 자리잡기용
-        .chartXAxis {
-            AxisMarks(values: .stride(by: .day)) { _ in
-                AxisValueLabel(format: .dateTime.day(), centered: true)
-                    .font(.defaultDayUnit)
-            }
-        }
-        .chartYAxis(.hidden)
     }
 }
 

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
@@ -58,6 +58,7 @@ struct SprintChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageSprint: Double
+    let betweenBarSpace: CGFloat = 65
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
@@ -58,7 +58,7 @@ struct SprintChart: View {
     let fastestWorkout: WorkoutData
     let slowestWorkout: WorkoutData
     let averageSprint: Double
-    let betweenBarSpace: CGFloat = 70
+    let betweenBarSpace = 70.0
     
     private func isMax(_ workout: WorkoutData) -> Bool {
         workout == fastestWorkout
@@ -69,92 +69,48 @@ struct SprintChart: View {
     }
     
     var body: some View {
-        if #available(iOS 17.0, *) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("Sprint", 0),
-                            yEnd: .value("Sprint", workout.sprint)
-                        )
-                        .foregroundStyle(isMax(workout) ? .sprintMax
-                                         : (isMin(workout) ? .sprintMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.sprint.formatted() + "회")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
+        ScrollView(.horizontal, showsIndicators: false) {
+            Chart {
+                ForEach(0..<workouts.count, id: \.self) { index in
+                    let workout = workouts[index]
+                    
+                    BarMark(
+                        x: .value("Order", index),
+                        yStart: .value("Sprint", 0),
+                        yEnd: .value("Sprint", workout.sprint)
+                    )
+                    .foregroundStyle(isMax(workout) ? .sprintMax
+                                     : (isMin(workout) ? .sprintMin : .chartDefault))
+                    .cornerRadius(300, style: .continuous)
+                    // MARK: - Bar Chart Data, value 표시
+                    // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
+                    .annotation(position: .bottom, alignment: .center) {
+                        let isMaxOrMin = isMin(workout) || isMax(workout)
+                        VStack(spacing: 6) {
+                            Text(workout.sprint.formatted() + "회")
+                                .font(.maxValueUint)
+                                .foregroundStyle(.maxValueStyle)
+                                .opacity(isMaxOrMin ? 1.0 : 0.5)
+                                .padding(.top, 8)
+                            
+                            Text("\(workout.day)일")
+                                .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
+                                .foregroundStyle(.defaultDayStyle)
                         }
                     }
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
-            .defaultScrollAnchor(.trailing)
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Chart {
-                    ForEach(0..<workouts.count, id: \.self) { index in
-                        let workout = workouts[index]
-                        
-                        BarMark(
-                            x: .value("Order", index),
-                            yStart: .value("Sprint", 0),
-                            yEnd: .value("Sprint", workout.sprint)
-                        )
-                        .foregroundStyle(isMax(workout) ? .sprintMax
-                                         : (isMin(workout) ? .sprintMin : .chartDefault))
-                        .cornerRadius(300, style: .continuous)
-                        // MARK: - Bar Chart Data, value 표시
-                        // MARK: - 가장 밑에 일자 표시, 실제 보이는 용
-                        .annotation(position: .bottom, alignment: .center) {
-                            let isMaxOrMin = isMin(workout) || isMax(workout)
-                            VStack(spacing: 6) {
-                                Text(workout.sprint.formatted() + "회")
-                                    .font(.maxValueUint)
-                                    .foregroundStyle(.maxValueStyle)
-                                    .opacity(isMaxOrMin ? 1.0 : 0.5)
-                                    .padding(.top, 8)
-                                
-                                Text("\(workout.day)일")
-                                    .font(isMaxOrMin ? .maxDayUnit : .defaultDayUnit)
-                                    .foregroundStyle(.defaultDayStyle)
-                            }
-                        }
-                    }
+            // MARK: - 가장 밑에 일자 표시, 자리잡기용
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day)) { _ in
+                    AxisValueLabel(format: .dateTime.day(), centered: true)
+                        .font(.defaultDayUnit)
                 }
-                // MARK: - 가장 밑에 일자 표시, 자리잡기용
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { _ in
-                        AxisValueLabel(format: .dateTime.day(), centered: true)
-                            .font(.defaultDayUnit)
-                    }
-                }
-                .chartYAxis(.hidden)
-                .frame(width: CGFloat(workouts.count) * betweenBarSpace)
             }
+            .chartYAxis(.hidden)
+            .frame(width: CGFloat(workouts.count) * betweenBarSpace)
         }
+        .backport.defaultScrollAnchor(.trailing)
     }
 }
 


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #295

## 🏃‍♂️ 구현/변경 사항
- 추세 차트 횡스크롤 구현했습니다. (거리 / 스프린트 / 속력 / 심박수)
- 전체 데이터의 값을 볼 수 있도록 수정하였습니다.
- 가장 최신 데이터가 스크린에 먼저 뜨도록 설정하였습니다.
- (추가) 메인뷰 버그 리포팅 여백 수정했습니다.

## 📷 스크린샷
![Apr-13-2024 00-45-05](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/106143629/6b25e172-5bc7-4d42-bf1b-921e54135061)


(여백 수정전)
<img width="231" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/106143629/357cb0a2-e370-446b-9b87-429f927afe3b">
(여백 수정후)
<img width="225" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/106143629/7b19b615-a9d2-4e0a-bf35-53fb66b7b07e">


## ✏️  ETC
- ios 17부터 적용 가능한 .chartScrollableAxes(.horizontal) 대신 ScrollView(.horizontal)과 전체 스크롤뷰의 frame을 정해주는 방식을 사용하였습니다.
- 하지만, 가장 최신 데이터를 스크린에 먼저 보여주는 과정에서 ios 17에서 적용 가능한 defaultScrollAnchor(_:) 함수를 사용했습니다. 이로인해 (다량의....!) 코드의 중복이 발생했습니다... 구선생님.. 호선생님.. 조언 환영합니다..

## 🙏To Reviewer
