### PR TITLE
fix: [#308] adjust loading experience

### DIFF
--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -40,8 +40,6 @@
 		BE010D3D2B0512680093A5FE /* Double+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE010D3B2B0512680093A5FE /* Double+extension.swift */; };
 		BE0639D82AE61BC2008D1D4E /* SplitControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0639D72AE61BC2008D1D4E /* SplitControlsView.swift */; };
 		BE0639DA2AE66D93008D1D4E /* SessionPagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0639D92AE66D93008D1D4E /* SessionPagingView.swift */; };
-		BE0AF4EF2BC7AA3C00D4FDF2 /* SkeletonUI in Frameworks */ = {isa = PBXBuildFile; productRef = BE0AF4EE2BC7AA3C00D4FDF2 /* SkeletonUI */; };
-		BE0AF4F12BC7AA4500D4FDF2 /* SkeletonUI in Frameworks */ = {isa = PBXBuildFile; productRef = BE0AF4F02BC7AA4500D4FDF2 /* SkeletonUI */; };
 		BE16B7C32B0B7D0300192C3B /* TrophyCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE16B7C22B0B7D0300192C3B /* TrophyCollectionView.swift */; };
 		BE22D6352AE586AA009035C9 /* GameProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE22D6302AE586AA009035C9 /* GameProgressView.swift */; };
 		BE22D6372AE586AA009035C9 /* SprintStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE22D6322AE586AA009035C9 /* SprintStatusView.swift */; };
@@ -90,6 +88,7 @@
 		BE4A91582B011C8B004AAFA3 /* SprintChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4A91572B011C8B004AAFA3 /* SprintChart.swift */; };
 		BE4B72742BAAA87300034C0F /* Dictionary+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4B72732BAAA87300034C0F /* Dictionary+extension.swift */; };
 		BE4B72752BAAA87300034C0F /* Dictionary+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4B72732BAAA87300034C0F /* Dictionary+extension.swift */; };
+		BE4CAB152BCE044100CE0020 /* SkeletonUI in Frameworks */ = {isa = PBXBuildFile; productRef = BE4CAB142BCE044100CE0020 /* SkeletonUI */; };
 		BE91CF402BBE43BC00F0EB6F /* RadarChartShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE91CF3F2BBE43BC00F0EB6F /* RadarChartShape.swift */; };
 		BE93F1912B00937000C33756 /* TextBorder+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE93F1902B00937000C33756 /* TextBorder+extension.swift */; };
 		BE93F1922B00937000C33756 /* TextBorder+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE93F1902B00937000C33756 /* TextBorder+extension.swift */; };
@@ -291,7 +290,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE0AF4EF2BC7AA3C00D4FDF2 /* SkeletonUI in Frameworks */,
+				BE4CAB152BCE044100CE0020 /* SkeletonUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,7 +298,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE0AF4F12BC7AA4500D4FDF2 /* SkeletonUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -778,7 +776,7 @@
 			);
 			name = SoccerBeat;
 			packageProductDependencies = (
-				BE0AF4EE2BC7AA3C00D4FDF2 /* SkeletonUI */,
+				BE4CAB142BCE044100CE0020 /* SkeletonUI */,
 			);
 			productName = SoccerBeat;
 			productReference = D3C5000F2AE36F3F00EFAEFF /* SoccerBeat.app */;
@@ -799,7 +797,6 @@
 			);
 			name = "SoccerBeat Watch App";
 			packageProductDependencies = (
-				BE0AF4F02BC7AA4500D4FDF2 /* SkeletonUI */,
 			);
 			productName = "SoccerBeat Watch App";
 			productReference = D3C5001F2AE36F3F00EFAEFF /* SoccerBeat Watch App.app */;
@@ -1419,12 +1416,7 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		BE0AF4EE2BC7AA3C00D4FDF2 /* SkeletonUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BE4982B32BC7A74F003208E3 /* XCRemoteSwiftPackageReference "SkeletonUI" */;
-			productName = SkeletonUI;
-		};
-		BE0AF4F02BC7AA4500D4FDF2 /* SkeletonUI */ = {
+		BE4CAB142BCE044100CE0020 /* SkeletonUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = BE4982B32BC7A74F003208E3 /* XCRemoteSwiftPackageReference "SkeletonUI" */;
 			productName = SkeletonUI;

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "12e207aad7a0cfa82e9a513efcadea51181b6321e055d46c8781d398b55052ea",
   "pins" : [
     {
       "identity" : "skeletonui",
@@ -29,5 +28,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/SoccerBeat/SoccerBeat/SoccerBeatApp.swift
+++ b/SoccerBeat/SoccerBeat/SoccerBeatApp.swift
@@ -22,7 +22,7 @@ struct SoccerBeatApp: App {
     var body: some Scene {
         WindowGroup {
             //             if Authorization == sharingDenied, 명시적으로 거절함.
-            ZStack {
+            Group {
                 if noHealth {
                     NoAuthorizationView(requestingAuth: .health)
                 } else if noLocation {
@@ -44,6 +44,12 @@ struct SoccerBeatApp: App {
                         await self.healthInteracter.fetchWorkoutData()
                     }
                 }
+            }
+            .task {
+                healthInteracter.requestAuthorization()
+            }
+            .onReceive(healthInteracter.authSuccess) {
+                Task { await healthInteracter.fetchWorkoutData() }
             }
         }
     }

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/ContentView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/ContentView.swift
@@ -20,34 +20,25 @@ struct ContentView: View {
     
     var body: some View {
         NavigationStack {
-            ZStack {
-                // TODO: - 건강 경보라고만 되어있는데 어떤 경보인지 알 수 있도록 renaming
-                if healthAlert {
-                    HealthAlertView(showingAlert: $healthAlert)
-                } else if healthInteractor.isLoading {
-                    LoadingView(workouts: $workouts)
-                } else if !healthInteractor.isLoading {
-                    if workouts.isEmpty {
-                        EmptyDataView()
-                    } else {
-                        MainView(workouts: $workouts)
-                    }
+            if healthAlert {
+                HealthAlertView(showingAlert: $healthAlert)
+            } else if healthInteractor.isLoading {
+                LoadingView()
+            } else {
+                if workouts.isEmpty {
+                    EmptyDataView()
+                } else {
+                    MainView(workouts: $workouts)
                 }
             }
-            .task {
-                healthInteractor.requestAuthorization()
-            }
-            .onReceive(healthInteractor.authSuccess) {
-                Task { await healthInteractor.fetchWorkoutData() }
-            }
-            .onReceive(healthInteractor.fetchWorkoutsSuccess) { workouts in
-                self.workouts = workouts
-            }
-            .onAppear {
-                // 음악을 틀기
-                if soundManager.isMusicPlaying {
-                    soundManager.playBackground()
-                }
+        }
+        .onReceive(healthInteractor.fetchWorkoutsSuccess) { workouts in
+            self.workouts = workouts
+        }
+        .onAppear {
+            // 음악을 틀기
+            if soundManager.isMusicPlaying {
+                soundManager.playBackground()
             }
         }
         .tint(.white)

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
@@ -80,7 +80,6 @@ struct MainView: View {
                         }
                         Text("최근 경기")
                             .font(.mainTitleText)
-                            .skeleton(with: healthInteractor.isLoading)
                     }
                     
                     
@@ -89,7 +88,6 @@ struct MainView: View {
                         ProfileView()
                     } label: {
                         CardFront(degree: .constant(0), width: 72, height: 110)
-                            .skeleton(with: healthInteractor.isLoading)
                     }
                 }
                 .padding()
@@ -111,7 +109,6 @@ struct MainView: View {
                                         ViewControllerContainer(RadarViewController(radarAverageValue: average, radarAtypicalValue: recent))                              .scaleEffect(CGSize(width: 0.7, height: 0.7))
                                                                                 .fixedSize()
                                                                                 .frame(width: 210, height: 210)
-                                            .skeleton(with: healthInteractor.isLoading)
                                     }
                                     Spacer()
                                     
@@ -121,7 +118,6 @@ struct MainView: View {
                                         VStack(alignment: .leading) {
                                             Text(currentLocation)
                                                 .font(.mainDateLocation)
-                                                .skeleton(with: healthInteractor.isLoading)
                                                 .foregroundStyle(.mainDateTime)
                                                 .opacity(0.8)
                                                 .task {
@@ -131,7 +127,7 @@ struct MainView: View {
                                                 }
                                             Group {
                                                 Text("경기 시간")
-                                                    .skeleton(with: healthInteractor.isLoading)
+
                                                 if !workouts.isEmpty {
                                                     Text(workouts[0].time)
                                                 }
@@ -182,7 +178,6 @@ struct MainView: View {
                             
                             Spacer()
                         }
-                        .skeleton(with: healthInteractor.isLoading)
                         .padding()
                     }
                 }
@@ -191,7 +186,6 @@ struct MainView: View {
                     .frame(height: 80)
                 
                 AnalyticsView()
-                    .skeleton(with: healthInteractor.isLoading)
             }
         }
         .refreshable {

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/MainView.swift
@@ -80,7 +80,7 @@ struct MainView: View {
                         }
                         Text("최근 경기")
                             .font(.mainTitleText)
-                            .skeleton(with: workouts.isEmpty)
+                            .skeleton(with: healthInteractor.isLoading)
                     }
                     
                     
@@ -89,7 +89,7 @@ struct MainView: View {
                         ProfileView()
                     } label: {
                         CardFront(degree: .constant(0), width: 72, height: 110)
-                            .skeleton(with: workouts.isEmpty)
+                            .skeleton(with: healthInteractor.isLoading)
                     }
                 }
                 .padding()
@@ -111,8 +111,8 @@ struct MainView: View {
                                         ViewControllerContainer(RadarViewController(radarAverageValue: average, radarAtypicalValue: recent))                              .scaleEffect(CGSize(width: 0.7, height: 0.7))
                                                                                 .fixedSize()
                                                                                 .frame(width: 210, height: 210)
+                                            .skeleton(with: healthInteractor.isLoading)
                                     }
-                                    
                                     Spacer()
                                     
                                     // 최근 경기 미리보기 오른쪽
@@ -121,7 +121,7 @@ struct MainView: View {
                                         VStack(alignment: .leading) {
                                             Text(currentLocation)
                                                 .font(.mainDateLocation)
-                                                .skeleton(with: workouts.isEmpty)
+                                                .skeleton(with: healthInteractor.isLoading)
                                                 .foregroundStyle(.mainDateTime)
                                                 .opacity(0.8)
                                                 .task {
@@ -131,7 +131,7 @@ struct MainView: View {
                                                 }
                                             Group {
                                                 Text("경기 시간")
-                                                    .skeleton(with: workouts.isEmpty)
+                                                    .skeleton(with: healthInteractor.isLoading)
                                                 if !workouts.isEmpty {
                                                     Text(workouts[0].time)
                                                 }
@@ -182,7 +182,7 @@ struct MainView: View {
                             
                             Spacer()
                         }
-                        .skeleton(with: workouts.isEmpty)
+                        .skeleton(with: healthInteractor.isLoading)
                         .padding()
                     }
                 }
@@ -191,11 +191,11 @@ struct MainView: View {
                     .frame(height: 80)
                 
                 AnalyticsView()
-                    .skeleton(with: workouts.isEmpty)
+                    .skeleton(with: healthInteractor.isLoading)
             }
         }
         .refreshable {
-            healthInteractor.requestAuthorization()
+            await healthInteractor.fetchWorkoutData()
         }
         .padding(.horizontal)
         .navigationTitle("")

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/Subviews/EmptyDataView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/Subviews/EmptyDataView.swift
@@ -4,11 +4,9 @@
 //
 //  Created by Gucci on 4/15/24.
 //
-import SkeletonUI
 import SwiftUI
 
 struct EmptyDataView: View {
-    @EnvironmentObject var healthInteractor: HealthInteractor
     private let emptyDataMessage = "저장된 경기 기록이 없습니다."
     
     var body: some View {
@@ -25,11 +23,9 @@ struct EmptyDataView: View {
                     // 최근 경기
                     VStack(alignment: .leading, spacing: 4) {
                         InformationButton(message: "가장 최근에 기록한 경기를 만나보세요")
-                            .skeleton(with: healthInteractor.isLoading)
                         
                         Text("최근 경기")
                             .font(.mainTitleText)
-                            .skeleton(with: healthInteractor.isLoading)
                     }
                     
                     Spacer()
@@ -42,24 +38,20 @@ struct EmptyDataView: View {
                     }
                 }
                 .padding(.horizontal, 16)
-                .skeleton(with: healthInteractor.isLoading)
                     
                 // 최근 경기 알림판
                 ZStack {
                     LightRectangleView()
                         .frame(height: 234)
-                        .opacity(healthInteractor.isLoading ? 0 : 1)
                         .padding(.horizontal, 16)
                         .foregroundStyle(.white.opacity(0.1))
                     
                     VStack(spacing: nil) {
                         highlightedInfomationalText(emptyDataMessage)
-                            .skeleton(with: healthInteractor.isLoading)
                             .padding(.top, 46)
                         
                         Text("애플워치를 차고 당신의 첫 번째 경기를 기록해 보세요!")
                             .font(.notoSans(size: 14))
-                            .skeleton(with: healthInteractor.isLoading)
                             .foregroundStyle(.subInfomational)
                             .padding(.top, 20)
                     }
@@ -68,11 +60,9 @@ struct EmptyDataView: View {
                 // 추세
                 VStack(alignment: .leading, spacing: 4) {
                     InformationButton(message: "경기 퍼포먼스의 변화 추세를 살펴보세요")
-                        .skeleton(with: healthInteractor.isLoading)
                     
                     Text("추세")
                         .font(.mainTitleText)
-                        .skeleton(with: healthInteractor.isLoading)
                 }
                 .padding(.leading, 16)
                 .padding(.top, 40)
@@ -86,7 +76,6 @@ struct EmptyDataView: View {
                     
                     VStack(spacing: nil) {
                         highlightedInfomationalText(emptyDataMessage)
-                            .skeleton(with: healthInteractor.isLoading)
                     }
                 }
                 

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/Subviews/EmptyDataView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/Subviews/EmptyDataView.swift
@@ -4,10 +4,11 @@
 //
 //  Created by Gucci on 4/15/24.
 //
-
+import SkeletonUI
 import SwiftUI
 
 struct EmptyDataView: View {
+    @EnvironmentObject var healthInteractor: HealthInteractor
     private let emptyDataMessage = "저장된 경기 기록이 없습니다."
     
     var body: some View {
@@ -24,9 +25,11 @@ struct EmptyDataView: View {
                     // 최근 경기
                     VStack(alignment: .leading, spacing: 4) {
                         InformationButton(message: "가장 최근에 기록한 경기를 만나보세요")
+                            .skeleton(with: healthInteractor.isLoading)
                         
                         Text("최근 경기")
                             .font(.mainTitleText)
+                            .skeleton(with: healthInteractor.isLoading)
                     }
                     
                     Spacer()
@@ -39,20 +42,24 @@ struct EmptyDataView: View {
                     }
                 }
                 .padding(.horizontal, 16)
+                .skeleton(with: healthInteractor.isLoading)
                     
                 // 최근 경기 알림판
                 ZStack {
                     LightRectangleView()
                         .frame(height: 234)
+                        .opacity(healthInteractor.isLoading ? 0 : 1)
                         .padding(.horizontal, 16)
                         .foregroundStyle(.white.opacity(0.1))
                     
                     VStack(spacing: nil) {
                         highlightedInfomationalText(emptyDataMessage)
+                            .skeleton(with: healthInteractor.isLoading)
                             .padding(.top, 46)
                         
                         Text("애플워치를 차고 당신의 첫 번째 경기를 기록해 보세요!")
                             .font(.notoSans(size: 14))
+                            .skeleton(with: healthInteractor.isLoading)
                             .foregroundStyle(.subInfomational)
                             .padding(.top, 20)
                     }
@@ -61,9 +68,11 @@ struct EmptyDataView: View {
                 // 추세
                 VStack(alignment: .leading, spacing: 4) {
                     InformationButton(message: "경기 퍼포먼스의 변화 추세를 살펴보세요")
+                        .skeleton(with: healthInteractor.isLoading)
                     
                     Text("추세")
                         .font(.mainTitleText)
+                        .skeleton(with: healthInteractor.isLoading)
                 }
                 .padding(.leading, 16)
                 .padding(.top, 40)
@@ -77,6 +86,7 @@ struct EmptyDataView: View {
                     
                     VStack(spacing: nil) {
                         highlightedInfomationalText(emptyDataMessage)
+                            .skeleton(with: healthInteractor.isLoading)
                     }
                 }
                 
@@ -94,10 +104,12 @@ struct EmptyDataView: View {
 }
 
 #Preview {
+    @StateObject var healthInteractor = HealthInteractor.shared
     @StateObject var profileModel = ProfileModel(healthInteractor: HealthInteractor.shared)
     
     return NavigationStack {
         EmptyDataView()
               .environmentObject(profileModel)
+              .environmentObject(healthInteractor)
     }
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/HomeView/Subviews/LoadingView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/HomeView/Subviews/LoadingView.swift
@@ -9,22 +9,19 @@ import SkeletonUI
 import SwiftUI
 
 struct LoadingView: View {
-    @Binding var workouts: [WorkoutData]
+    @EnvironmentObject var healthInteractor: HealthInteractor
     
     var body: some View {
         ForEach(0..<6) { _ in
-            ZStack {
-                LightRectangleView()
-                
-                Text("Loading Now")
-            }
-            .skeleton(with: workouts.isEmpty)
+            Text("Loading Now")
+                .skeleton(with: healthInteractor.isLoading)
         }
     }
 }
 
 #Preview {
-    @State var examples: [WorkoutData] = []
+    @StateObject var healthInteractor = HealthInteractor.shared
 
-    return LoadingView(workouts: $examples)
+    return LoadingView()
+        .environmentObject(healthInteractor)
 }


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #308 

## 🏃‍♂️ 구현/변경 사항
- EmptyDataView, MainView에서 Loading 관련 스켈레톤 UI 제거
- ContentView에서 wokroutdata를 불러오는 로직을 SoccerBeatApp으로 이관
- 백그라운드에서 활성상태로 앱이 넘어올 때 LoadingView가 보이는데, 이 때 SkeletonUI가 동작하지않음
- HealthInteractor에서 Main Thread를 이용해야하는 경우 MainActor를 직접적으로 사용하도록 수정

## 📷 영상
앱이 백그라운드로 갔다가 포어그라운드로 오는 흐름을 중점으로 촬영하였습니다. 

- Simulator(데이터 없음)
https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/e750d284-96ea-4b95-b058-61daa003a26a

- 실기기(데이터 있음)
https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/fc943ed9-3f68-4cee-8eca-40cbce9c578d


## ✏️  ETC


## 🙏To Reviewer
