### PR TITLE
fix: [#312] MatchRecap Graph UI Edit

### DIFF
--- a/SoccerBeat/Common/Utiles/Color+extension.swift
+++ b/SoccerBeat/Common/Utiles/Color+extension.swift
@@ -117,6 +117,11 @@ extension ShapeStyle where Self == Color {
     static var tooltipTextColor: Self { .init(hex: 0xABFFE6) }
     static var tooltipBackgroundColor: Self { .init(hex: 0x191919)}
     
+    // MARK: - MatchRecapView Graph
+    static var averageFillColor: Self { .init(hex: 0x47FFFF, alpha: 0.5) }
+    static var averageStokeColor: Self { .init(hex: 0x03FFE0) }
+    static var maxFillColor: Self { Color.clear }
+    static var maxStrokeColor: Self { .init(hex: 0xFF007A, alpha: 0.7) }
 }
 
 extension ShapeStyle where Self == LinearGradient {

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		685D7B652AE529E800783433 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B642AE529E800783433 /* AnalyticsView.swift */; };
 		685D7B6E2AE5396200783433 /* LightRectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B6D2AE5396200783433 /* LightRectangleView.swift */; };
 		685D7B752AE53DC400783433 /* SpeedChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D7B742AE53DC400783433 /* SpeedChart.swift */; };
+		686E998A2BD0DB4900B9FD56 /* NameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686E99892BD0DB4900B9FD56 /* NameFieldView.swift */; };
 		6876C0BF2B0B7F73005C6872 /* FifaBackground.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6876C0BE2B0B7F73005C6872 /* FifaBackground.mp3 */; };
 		6898F2852AEFD7FC0075A573 /* SprintView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6898F2842AEFD7FC0075A573 /* SprintView.swift */; };
 		68B0732E2AF11847004C723F /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B0732C2AF11847004C723F /* AlertView.swift */; };
@@ -193,6 +194,7 @@
 		685D7B642AE529E800783433 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
 		685D7B6D2AE5396200783433 /* LightRectangleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightRectangleView.swift; sourceTree = "<group>"; };
 		685D7B742AE53DC400783433 /* SpeedChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedChart.swift; sourceTree = "<group>"; };
+		686E99892BD0DB4900B9FD56 /* NameFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameFieldView.swift; sourceTree = "<group>"; };
 		6876C0BE2B0B7F73005C6872 /* FifaBackground.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = FifaBackground.mp3; sourceTree = "<group>"; };
 		6898F2842AEFD7FC0075A573 /* SprintView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprintView.swift; sourceTree = "<group>"; };
 		68B0732C2AF11847004C723F /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
@@ -656,6 +658,7 @@
 				BE323D3F2B0C80C200F289D4 /* TooltipView.swift */,
 				682D64842AFD1BA000D7F07B /* ProfileImage.swift */,
 				682D64862AFD1D8500D7F07B /* Profile.swift */,
+				686E99892BD0DB4900B9FD56 /* NameFieldView.swift */,
 			);
 			path = Subviews;
 			sourceTree = "<group>";
@@ -992,6 +995,7 @@
 				D37F6ABC2B0CDFAC00A37E4F /* HealthAlertView.swift in Sources */,
 				BEF479BE2BCA6C1C00C79362 /* LoadingView.swift in Sources */,
 				6851E6E32B0C8E7F007D1DD8 /* Text+extension.swift in Sources */,
+				686E998A2BD0DB4900B9FD56 /* NameFieldView.swift in Sources */,
 				682D64892AFDBF8C00D7F07B /* PhotoSelectButtonView.swift in Sources */,
 				BEDE523E2B03BFF800BBFD94 /* Analyzable.swift in Sources */,
 				FBA3DA622B00E6EF0025AD7B /* ShareView.swift in Sources */,

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -11,6 +11,13 @@ struct MatchRecapView: View {
     @EnvironmentObject var healthInteractor: HealthInteractor
     @State private var userName = ""
     @Binding var userWorkouts: [WorkoutData]
+    
+    private var lastName: String {
+        guard let lastName = userName
+            .split(separator: " ")
+            .compactMap({ String($0) }).last else { return "" }
+        return lastName
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -35,7 +42,8 @@ struct MatchRecapView: View {
             
             HStack {
                 VStack(alignment: .leading, spacing: 0.0) {
-                    Text(userName.isEmpty ? "Player, " : "Player \(userName.split(separator: " ").last!),")
+                    // view
+                    Text("Player \(lastName),")
                         .lineLimit(1)
                     Text("Your past games")
                 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/RadarChartShape.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/RadarChartShape.swift
@@ -52,20 +52,20 @@ struct RadarChartView: View {
             
             // MARK: - 평균 데이터 레이어
             RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
-                .fill(Color(UIColor(red:0.282,  green:1,  blue:1, alpha:0.5)))
+                .fill(.averageFillColor)
                 .overlay(
                     RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
-                        .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
-                        .foregroundStyle(Color(UIColor(red:0,  green:1,  blue:0.878, alpha:1)))
+                        .stroke(style: StrokeStyle(lineWidth: 3.5, lineCap: .round, lineJoin: .round))
+                        .foregroundStyle(.averageStokeColor)
                 )
             
             // MARK: - 최고 데이터 레이어
             RadarChartShape(dataPoints: maximumDataPoints, maxValue: limitValue)
-                .fill(Color.clear)
+                .fill(.maxFillColor)
                 .overlay(
                     RadarChartShape(dataPoints: maximumDataPoints, maxValue: limitValue)
-                        .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
-                        .foregroundStyle(Color(UIColor(red:1,  green:0,  blue:0.478, alpha:0.7)))
+                        .stroke(style: StrokeStyle(lineWidth: 3.5, lineCap: .round, lineJoin: .round))
+                        .foregroundStyle(.maxStrokeColor)
                 )
         }
         .rotationEffect(.degrees(-90))
@@ -78,4 +78,5 @@ struct RadarChartView: View {
     let maxValue = 1.0
     
     return RadarChartView(averageDataPoints: averageDataPoints, maximumDataPoints: currentDataPoints, limitValue: maxValue)
+ 
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/RadarChartShape.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/RadarChartShape.swift
@@ -49,28 +49,26 @@ struct RadarChartView: View {
     var body: some View {
         ZStack {
             // MARK: - max line border
-//            ForEach(0..<averageDataPoints.count) { index in
-//                RadarChartShape(dataPoints: Array(repeating: limitValue, count: averageDataPoints.count), maxValue: limitValue)
-//                    .stroke(Color.gray, lineWidth: 0.5)
-//            }
             
             // MARK: - 평균 데이터 레이어
             RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
-                .fill(Color.blue.opacity(0.3))
+                .fill(Color(UIColor(red:0.282,  green:1,  blue:1, alpha:0.5)))
                 .overlay(
                     RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
-                        .stroke(Color.blue, lineWidth: 2)
+                        .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+                        .foregroundStyle(Color(UIColor(red:0,  green:1,  blue:0.878, alpha:1)))
                 )
             
             // MARK: - 최고 데이터 레이어
             RadarChartShape(dataPoints: maximumDataPoints, maxValue: limitValue)
-                .fill(Color.red.opacity(0.3))
+                .fill(Color.clear)
                 .overlay(
                     RadarChartShape(dataPoints: maximumDataPoints, maxValue: limitValue)
-                        .stroke(Color.red, lineWidth: 2)
+                        .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+                        .foregroundStyle(Color(UIColor(red:1,  green:0,  blue:0.478, alpha:0.7)))
                 )
         }
-//        .frame(width: 300, height: 300)
+        .rotationEffect(.degrees(-90))
     }
 }
 

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -69,7 +69,7 @@ struct ProfileView: View {
                                 NameFieldView()
                                 
                             }
-                            .font(.custom("SFProDisplay-HeavyItalic", size: 36))
+                            .font(.mainTitleText)
                         }
                     }
                     
@@ -145,42 +145,4 @@ extension View {
 #Preview {
     ProfileView()
         .environmentObject(ProfileModel(healthInteractor: HealthInteractor()))
-}
-
-struct NameFieldView: View {
-    @State private var userName = ""
-    let nameLength = 15
-    
-    var body: some View {
-        VStack(spacing: 0) {
-            ZStack {
-                if !userName.isEmpty {
-                    Text(userName)
-                        .foregroundStyle(.clear)
-                        .padding(.horizontal, 32)
-                        .frame(height: 40)
-                        .overlay {
-                            Capsule()
-                                .stroke(style: .init(lineWidth: 0.8))
-                                .frame(height: 40)
-                                .foregroundColor(userName.count >= nameLength + 1 ? .red : .brightmint)
-                        }
-                }
-                
-                TextField("Name", text: $userName)
-                    .padding(.horizontal, 32)
-                    .frame(height: 40)
-                    .limitText($userName, to: nameLength)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(1)
-                    .onChange(of: userName) { _ in
-                        UserDefaults.standard.set(userName, forKey: "userName")
-                    }
-            }
-        }
-        .offset(y: 24)
-        .onAppear {
-            userName = UserDefaults.standard.string(forKey: "userName") ?? ""
-        }
-    }
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -38,7 +38,6 @@ struct ProfileView: View {
                                             .opacity(isFlipped ? 1 : 0)
                                             .padding(.top, 10)
                                     }
-                                    //                                    .offset(y: 20)
                                     
                                     Spacer()
                                         .frame(width: 24)
@@ -65,9 +64,7 @@ struct ProfileView: View {
                                     }
                                     Spacer()
                                 }
-                                
                                 NameFieldView()
-                                
                             }
                             .font(.mainTitleText)
                         }

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -10,10 +10,8 @@ import SwiftUI
 struct ProfileView: View {
     @EnvironmentObject var profileModel: ProfileModel
     @State private var isFlipped = false
-    @State private var userName = ""
     @State private var userImage: UIImage?
     @FocusState private var isFocused: Bool
-    let nameLength = 15
     
     var body: some View {
         NavigationStack {
@@ -22,59 +20,56 @@ struct ProfileView: View {
                     HStack {
                         VStack {
                             HStack {
-                                InformationButton(message: "나의 선수 카드와 최대 능력치를 만나보세요.")
+                                InformationButton(message: " 나의 선수 카드와 최대 능력치를 만나보세요.")
                                 Spacer()
                             }
                             .padding(.top, 48)
                             .padding(.bottom, 30)
                             
-                                VStack(spacing: 0) {
-                                    HStack {
-                                        Text("선수 프로필")
-                                            .font(.matchDetailSubTitle)
-                                            .foregroundStyle(.shareViewSubTitleTint)
-                                        Spacer()
-                                    }
-                                    
-                                    VStack(spacing: 0) {
-                                        ZStack {
-                                            if !userName.isEmpty {
-                                                Text(userName)
-                                                    .foregroundStyle(.clear)
-                                                    .padding(.horizontal)
-                                                    .frame(height: 40)
-                                                    .overlay {
-                                                        Capsule()
-                                                            .stroke(style: .init(lineWidth: 0.8))
-                                                            .frame(height: 40)
-                                                            .foregroundColor(userName.count >= nameLength + 1 ? .red : .brightmint)
-                                                    }
-                                            }
-                                            
-                                            TextField("Name", text: $userName)
-                                                .padding(.horizontal)
-                                                .frame(height: 40)
-                                                .limitText($userName, to: nameLength)
-                                                .multilineTextAlignment(.center)
-                                                .lineLimit(1)
-                                                .onChange(of: userName) { _ in
-                                                    UserDefaults.standard.set(userName, forKey: "userName")
-                                                }
-                                        }
-                                    }
-                                    .offset(y: 24)
-                                    
+                            VStack(spacing: 0) {
+                                HStack {
                                     VStack {
+                                        Spacer()
+                                        
                                         MyCardView(isFlipped: $isFlipped)
-                                            .frame(width: 210)
+                                            .frame(width: 95)
+                                        
                                         PhotoSelectButtonView()
                                             .opacity(isFlipped ? 1 : 0)
                                             .padding(.top, 10)
                                     }
-                                    .offset(y: 20)
-
+                                    //                                    .offset(y: 20)
+                                    
+                                    Spacer()
+                                        .frame(width: 24)
+                                    
+                                    VStack(alignment: .leading, spacing: nil) {
+                                        
+                                        Text("SBeat Card")
+                                            .font(.matchDetailSubTitle)
+                                            .foregroundStyle(.shareViewSubTitleTint)
+                                            .offset(y: -10)
+                                        HStack(spacing: nil) {
+                                            Text("How ")
+                                            Text("you")
+                                                .bold()
+                                                .foregroundStyle(.brightmint)
+                                        }
+                                        HStack(spacing: nil) {
+                                            Text("like")
+                                            Text("that?")
+                                                .foregroundStyle(.brightmint)
+                                                .highlighter(activity: .heartrate, isDefault: true)
+                                        }
+                                        .offset(y: -8)
+                                    }
+                                    Spacer()
                                 }
-                                .font(.custom("SFProDisplay-HeavyItalic", size: 36))
+                                
+                                NameFieldView()
+                                
+                            }
+                            .font(.custom("SFProDisplay-HeavyItalic", size: 36))
                         }
                     }
                     
@@ -112,9 +107,9 @@ struct ProfileView: View {
                     let maximumAbility = DataConverter.toLevels(profileModel.maxAbility)
                     
                     ViewControllerContainer(ProfileViewController(radarAverageValue: average, radarAtypicalValue: maximumAbility))
-                        .fixedSize()
-                        .frame(width: 304, height: 348)
-                        .zIndex(-1)
+                                            .fixedSize()
+                                            .frame(width: 304, height: 348)
+                                            .zIndex(-1)
                     
                     Spacer()
                         .frame(height: 110)
@@ -126,9 +121,7 @@ struct ProfileView: View {
                     hideKeyboard()
                 }
             }
-            .onAppear {
-                userName = UserDefaults.standard.string(forKey: "userName") ?? ""
-            }
+            
         }
         .toolbar {
             NavigationLink {
@@ -146,5 +139,48 @@ struct ProfileView: View {
 extension View {
     func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+
+#Preview {
+    ProfileView()
+        .environmentObject(ProfileModel(healthInteractor: HealthInteractor()))
+}
+
+struct NameFieldView: View {
+    @State private var userName = ""
+    let nameLength = 15
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                if !userName.isEmpty {
+                    Text(userName)
+                        .foregroundStyle(.clear)
+                        .padding(.horizontal, 32)
+                        .frame(height: 40)
+                        .overlay {
+                            Capsule()
+                                .stroke(style: .init(lineWidth: 0.8))
+                                .frame(height: 40)
+                                .foregroundColor(userName.count >= nameLength + 1 ? .red : .brightmint)
+                        }
+                }
+                
+                TextField("Name", text: $userName)
+                    .padding(.horizontal, 32)
+                    .frame(height: 40)
+                    .limitText($userName, to: nameLength)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(1)
+                    .onChange(of: userName) { _ in
+                        UserDefaults.standard.set(userName, forKey: "userName")
+                    }
+            }
+        }
+        .offset(y: 24)
+        .onAppear {
+            userName = UserDefaults.standard.string(forKey: "userName") ?? ""
+        }
     }
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/Subviews/MyCardView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/Subviews/MyCardView.swift
@@ -15,8 +15,8 @@ struct MyCardView: View {
     @State private var frontDegree = -90.0
     @Binding var isFlipped: Bool
     
-    private let width = 200.0
-    private let height = 280.0
+    private let width = 95.0
+    private let height = 125.0
     private let durationAndDelay = 0.25
     
     var body: some View {

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/Subviews/NameFieldView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/Subviews/NameFieldView.swift
@@ -1,0 +1,50 @@
+//
+//  NameFieldView.swift
+//  SoccerBeat
+//
+//  Created by jose Yun on 4/18/24.
+//
+
+import SwiftUI
+
+struct NameFieldView: View {
+    @State private var userName = ""
+    let nameLength = 15
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                if !userName.isEmpty {
+                    Text(userName)
+                        .foregroundStyle(.clear)
+                        .padding(.horizontal, 32)
+                        .frame(height: 40)
+                        .overlay {
+                            Capsule()
+                                .stroke(style: .init(lineWidth: 0.8))
+                                .frame(height: 40)
+                                .foregroundColor(userName.count >= nameLength + 1 ? .red : .brightmint)
+                        }
+                }
+                
+                TextField("Name", text: $userName)
+                    .padding(.horizontal, 32)
+                    .frame(height: 40)
+                    .limitText($userName, to: nameLength)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(1)
+                    .onChange(of: userName) { _ in
+                        UserDefaults.standard.set(userName, forKey: "userName")
+                    }
+            }
+        }
+        .offset(y: 24)
+        .onAppear {
+            userName = UserDefaults.standard.string(forKey: "userName") ?? ""
+        }
+    }
+}
+
+#Preview {
+    NameFieldView()
+}


### PR DESCRIPTION
## 🐲 관련 이슈
close #312 

## 🏃‍♂️ 구현/변경 사항
- 프로필 레이아웃 수정했습니다.
- 경기 리스트에서 그래프 색상과 라운딩 수정했습니다.

## 📷 스크린샷
![IMG_3369](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/52576276/a5089643-d517-4ec5-88f6-84e86e3f11fa)
![IMG_3368](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/52576276/44cbac96-6c25-4e49-a5c8-8f865203ce86)

## ✏️  ETC
- 웨슬리가 봐준 프로필입니다(짱!) 다만 프로필 카드를 뒤집은 상황이 충분히 고려된 것은 아니라 수정 여지가 있습니다.

## 🙏To Reviewer
- 아주 감사합니다. 