### PR TITLE
fix: [#315] 추세 데이터가 9개 뿐만 아니라 전체 데이터를 보여주게 수정

### DIFF
--- a/SoccerBeat/Common/Data/HealthInteractor.swift
+++ b/SoccerBeat/Common/Data/HealthInteractor.swift
@@ -46,7 +46,7 @@ final class HealthInteractor: ObservableObject {
         return formatter
     }()
     
-    @Published var recent9Games = [WorkoutData]()
+    @Published var recentGames = [WorkoutData]()
     @Published var recent4Games = [WorkoutData]()
     
     private(set) var monthly = [String: [WorkoutData]]()
@@ -225,25 +225,17 @@ final class HealthInteractor: ObservableObject {
 // MARK: - Chart Methods
 
 extension HealthInteractor {
-    
+
     private func settingForChartView(_ workouts: [WorkoutData]) async {
-        let nineGames: [WorkoutData] = {
-            let games = readRecentMatches(with: workouts, for: 9)
-            return sortWorkoutsForChart(games)
-        }()
         let fourGames: [WorkoutData] = {
             let games = readRecentMatches(with: workouts, for: 4)
             let sorted = sortWorkoutsForChart(games)
             return makeBlankWorkouts(with: sorted)
         }()
-        
-//        DispatchQueue.main.async { [unowned self] in
-//            recent4Games = fourGames
-//            recent9Games = nineGames
-//        }
+
         await MainActor.run {
             recent4Games = fourGames
-            recent9Games = nineGames
+            recentGames = sortWorkoutsForChart(workouts)
         }
     }
     

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/AnalyticsView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/AnalyticsView.swift
@@ -28,10 +28,10 @@ struct AnalyticsView: View {
                 ForEach(ActivityEnum.allCases, id: \.self) { activityType in
                     NavigationLink {
                         switch activityType {
-                        case .distance: DistanceChartView(workouts: healthInteractor.recent9Games)
-                        case .heartrate: BPMChartView(workouts: healthInteractor.recent9Games)
-                        case .speed: SpeedChartView(workouts: healthInteractor.recent9Games)
-                        case .sprint: SprintChartView(workouts: healthInteractor.recent9Games)
+                        case .distance: DistanceChartView(workouts: healthInteractor.recentGames)
+                        case .heartrate: BPMChartView(workouts: healthInteractor.recentGames)
+                        case .speed: SpeedChartView(workouts: healthInteractor.recentGames)
+                        case .sprint: SprintChartView(workouts: healthInteractor.recentGames)
                         }
                     } label: {
                         AnalyticsComponent(userWorkouts: healthInteractor.recent4Games, activityType: activityType)


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #315 

## 🏃‍♂️ 구현/변경 사항
추세 데이터가 전체를 변화하도록 수정하였습니다. 

## 📷 스크린샷
![IMG_373B66CC1F6F-1](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/00b9fc47-66b1-40f2-a67c-53c2585f05a5)


## ✏️  ETC


## 🙏To Reviewer
