### PR TITLE
fix: [#321] 스크린샷 촬영시 EnvironmentObject에 접근하는 로직을 제거

### DIFF
--- a/SoccerBeat/SoccerBeat/Sources/Features/Share/ShareView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Share/ShareView.swift
@@ -105,53 +105,22 @@ extension ShareView {
             }
         }
     }
-}
 
-extension ShareView {
-    func screenShot() {
-        let screenshot = body.takeScreenshot(origin: UIScreen.main.bounds.origin, size: UIScreen.main.bounds.size)
-        UIImageWriteToSavedPhotosAlbum(screenshot, self, nil, nil)
-        
-        PHPhotoLibrary.requestAuthorization( { status in
-            switch status {
-            case .authorized:
-                showingAlert = true
-            case .denied:
-                break
-            case .restricted, .notDetermined:
-                break
-            default:
-                break
-            }
-        })
-    }
-    
-    func share() {
-        let screenshot = body.takeScreenshot(origin: UIScreen.main.bounds.origin, size: UIScreen.main.bounds.size)
+    private func share() {
+        guard let screenshot = UIWindow.screenshot() else { return }
         let activityViewController = UIActivityViewController(activityItems: [screenshot], applicationActivities: nil)
         UIApplication.shared.windows.first?.rootViewController?.present(activityViewController, animated: true)
     }
 }
 
-extension UIView {
-    var screenShot: UIImage {
-        let rect = self.bounds
-        UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
-        let context: CGContext = UIGraphicsGetCurrentContext()!
-        self.layer.render(in: context)
-        let capturedImage: UIImage = UIGraphicsGetImageFromCurrentImageContext()!
-        return capturedImage
-    }
-}
+extension UIWindow {
+    static func screenshot() -> UIImage? {
+        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return nil }
 
-extension View {
-    func takeScreenshot(origin: CGPoint, size: CGSize) -> UIImage {
-        let window = UIWindow(frame: CGRect(origin: origin, size: size))
-        let hosting = UIHostingController(rootView: self)
-        hosting.view.frame = window.frame
-        window.addSubview(hosting.view)
-        window.makeKeyAndVisible()
-        return hosting.view.screenShot
+        let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
+        return renderer.image { context in
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        }
     }
 }
 


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #321 
[에러 났던 이유](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/issues/321#issuecomment-2117791737)
## 🏃‍♂️ 구현/변경 사항
- ShareView에서 EnvironmentObject에 접근하는 로직을 제거하여 공유 기능을 정상화

## 📷 스크린샷
- 프로필 이미지 선택하지 않고 공유
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/273a9bc3-6807-49b7-b4ee-4bb796235a57)

- 프로필 이미지 선택하고 공유
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/3db67704-5a78-41da-8a15-768f6d5f15aa)

