### PR TITLE
fix: [#329] 삭제 로직 순서 수정

### DIFF
--- a/SoccerBeat/Common/Data/HealthInteractor.swift
+++ b/SoccerBeat/Common/Data/HealthInteractor.swift
@@ -93,10 +93,10 @@ final class HealthInteractor: ObservableObject {
     }
     
     func delete(at offset: IndexSet) async throws {
-        hkWorkouts.remove(atOffsets: offset)
         for index in offset {
             try await healthStore.delete(hkWorkouts[index])
         }
+        hkWorkouts.remove(atOffsets: offset)
     }
     
     @Published var isLoading = false


### PR DESCRIPTION
## 🐲 관련 이슈
close #329 

## 🏃‍♂️ 구현/변경 사항
- 삭제 로직 순서 변경

## 📷 스크린샷
**변경전**
![IMG_6285](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/5749b37c-f4c9-4d13-afb2-aad5a7366da8)

**변경후**
![IMG_6286](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/36d4e7cf-057a-4d87-a658-0a55f947cf55)

## 🙏To Reviewer

- Fatal Error: Index out of range
<img width="1176" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/70abbe6e-f037-484e-b963-f323284cd8ec">

**원인:** 
- 먼저 HKwokrouts 라는 배열에서 삭제를 하고, 그 해당 인덱스에 접근하니 발생하는 문제였음
- 다른 기기에서 문제가 발생하지 않았던 이유: 여러개의 데이터가 있는 경우 해당 인덱스를 지워도 그 자리에 요소가 채워졌을 것임.
- - 만약 마지막 명기를 지웠더라면, 똑같은 에러가 발생했을 것

**해결책:** 
- 삭제 코드 순서 변경

정말 초보적인 실수인데 죄송합니다.