### PR TITLE
fix: [#331] 뷰 타이틀 위에 불필요한 공간 제거

### DIFF
--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchDetailView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchDetailView.swift
@@ -40,10 +40,6 @@ struct MatchTimeView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            
-            Spacer()
-                .frame(minHeight: 50)
-            
             HStack {
                 InformationButton(message: "경기의 상세 리포트를 만나보세요.")
                 Spacer()

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -21,9 +21,6 @@ struct MatchRecapView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            
-            Spacer()
-                .frame(height: 56)
             HStack {
                 InformationButton(message: "모든 경기를 한 눈에 확인해 보세요.")
                     .padding(.leading, 16)

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -23,7 +23,6 @@ struct ProfileView: View {
                                 InformationButton(message: "나의 선수 카드와 최대 능력치를 만나보세요.")
                                 Spacer()
                             }
-                            .padding(.top, 48)
                             .padding(.bottom, 30)
                             
                             VStack(spacing: 0) {

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/BPMChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/BPMChart.swift
@@ -25,7 +25,6 @@ struct BPMChartView: View {
                 InformationButton(message: "최근 심박수의 변화입니다.")
                 Spacer()
             }
-            .padding(.top, 54)
             
             VStack(alignment: .leading) {
                 Text("심박수")

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/DistanceChart.swift
@@ -26,7 +26,6 @@ struct DistanceChartView: View {
                 
                 Spacer()
             }
-            .padding(.top, 54)
             
             VStack(alignment: .leading) {
                 Text("뛴 거리")

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SpeedChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SpeedChart.swift
@@ -27,7 +27,7 @@ struct SpeedChartView: View {
                 
                 Spacer()
             }
-            .padding(.top, 54)
+            
             
             VStack(alignment: .leading) {
                 Text("최대 속도")

--- a/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/TrendCharts/Subviews/SprintChart.swift
@@ -25,7 +25,6 @@ struct SprintChartView: View {
                 InformationButton(message: "최근 스프린트 횟수의 변화입니다.")
                 Spacer()
             }
-            .padding(.top, 54)
             
             VStack(alignment: .leading) {
                 Text("스프린트")


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #331 

## 🏃‍♂️ 구현/변경 사항
- `MatchRecapView`, `MatchDetailView`, `ProfileView`, `SpeedChart`, `BPMChart`, `DistanceChart`, `SprintChart` 위에 불필요한 공백 제거

## 📷 스크린샷

<div align="center">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/c842eb8c-4f46-4b40-ae38-a4de34ba1756" width="25%">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/546d125e-faa1-4aae-83fa-680c9733b47a" width="25%">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/7cc438ca-9ebc-4c3b-b077-70a42c8ac962" width="25%">
</a>
</div>

<div align="center">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/03c7a484-7635-4b57-bed4-5321cb2ff46f" width="20%">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/273716a2-3a51-42cf-9b6f-8d3bc0c381ca" width="20%">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/14a35133-c317-477e-b496-f7f8403ab4e6" width="20%">
    <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Guryongpo/assets/50472122/987c82e7-4ceb-4dc0-8fe5-de91e300e31a" width="20%">
</a>
</div>




## ✏️  ETC
인포메이션 버튼이 타이틀 위에 오는것보다 타이틀의 HStack으로 구현해서 옆으로 오는건 어떨까요? 아니면 타이틀에 정확하게 겹치게 말이죠.
왜냐하면 지금은 큰 기능이 아닌데 많은 공간을 차지하고 있는것 같습니다. 아니면 Descriptional하게 타이틀 밑에 Subtitle로 친절하게 넣어 주는 방식도 있을 거 같네요. 


## 🙏To Reviewer
