### PR TITLE
[feat/gucci/358, 351] check healthkit config + 경기 종료 후 바로 명언뷰로 이동

### DIFF
--- a/SoccerBeat/SoccerBeat Watch App/SoccerBeatApp.swift
+++ b/SoccerBeat/SoccerBeat Watch App/SoccerBeatApp.swift
@@ -19,9 +19,6 @@ struct SoccerBeat_Watch_AppApp: App {
             NavigationView {
                 StartView()
             }
-            .sheet(isPresented: $workoutManager.showingSummaryView) {
-                SummaryView()
-            }
             .environmentObject(workoutManager)
             .environmentObject(matricsIndicator)
             .environment(\.locale, .current)

--- a/SoccerBeat/SoccerBeat Watch App/Sources/Features/EndRecording/SummaryView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/Features/EndRecording/SummaryView.swift
@@ -26,7 +26,7 @@ struct SummaryView: View {
 
                 Button {
                     workoutManager.showingSummaryView = false
-                    workoutManager.showingPrecount = false
+
                 } label: {
                     Text("완료")
                         .font(.summaryDoneButton)
@@ -43,6 +43,7 @@ struct SummaryView: View {
                     try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
                     withAnimation {
                         isShowingSummary.toggle()
+                        workoutManager.showingPrecount = false
                     }
                 }
         }

--- a/SoccerBeat/SoccerBeat Watch App/Sources/Features/EndRecording/SummaryView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/Features/EndRecording/SummaryView.swift
@@ -10,6 +10,7 @@ import HealthKit
 
 struct SummaryView: View {
     @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var workoutManager: WorkoutManager
     @EnvironmentObject var matricsIndicator: MatricsIndicator
     @State private var isShowingSummary = false
     
@@ -24,7 +25,8 @@ struct SummaryView: View {
                 SummaryComponent(title: "파워", content:  matricsIndicator.power.rounded(at: 1) + " w")
 
                 Button {
-                    dismiss()
+                    workoutManager.showingSummaryView = false
+                    workoutManager.showingPrecount = false
                 } label: {
                     Text("완료")
                         .font(.summaryDoneButton)
@@ -37,11 +39,10 @@ struct SummaryView: View {
         } else {
             PhraseView()
                 .navigationBarHidden(true)
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0 ) {
-                        withAnimation {
-                            isShowingSummary.toggle()
-                        }
+                .task {
+                    try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
+                    withAnimation {
+                        isShowingSummary.toggle()
                     }
                 }
         }

--- a/SoccerBeat/SoccerBeat Watch App/Sources/Features/StartPauseControl/SplitControlsView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/Features/StartPauseControl/SplitControlsView.swift
@@ -105,13 +105,10 @@ private extension SplitControlsView {
     func sessionControlButton(type sessionControl: SessionControl) -> some View {
         let action = {
             switch sessionControl {
-            // TODO: - pause, resume 인 경우에는 어떻게 화면전환이 되는지 모르겠음(end 일 때는 dismiss)
             case .resumeAndStop:
                 workoutManager.togglePause()
             case .end:
                 workoutManager.endWorkout()
-                workoutManager.showingPrecount = false
-                dismiss()
             }
         }
         

--- a/SoccerBeat/SoccerBeat Watch App/Sources/Features/StartPauseControl/StartView.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/Features/StartPauseControl/StartView.swift
@@ -14,7 +14,11 @@ struct StartView: View {
 
     var body: some View {
         VStack {
-            if !workoutManager.showingPrecount {
+            if workoutManager.showingSummaryView {
+                SummaryView()
+            } else if workoutManager.showingPrecount {
+                PrecountView()
+            } else {
                 ZStack {
                     Image(.backgroundGlow)
                         .resizable()
@@ -34,9 +38,6 @@ struct StartView: View {
                               dismissButton: .default(Text("close")))
                     }
                 }
-
-            } else {
-                PrecountView()
             }
         }
         .buttonStyle(.borderless)

--- a/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WatchWorkoutManager.swift
@@ -94,7 +94,6 @@ final class WorkoutManager: NSObject, ObservableObject {
                 configuration: configuration
             )
         } catch {
-            // session init은 실패할 가능성이 없어요. 저렇게 `.running` 처럼 점을 찍어서 선언하면 말이죠.
             NSLog(error.localizedDescription)
         }
         builder = session?.associatedWorkoutBuilder()
@@ -185,33 +184,5 @@ final class WorkoutManager: NSObject, ObservableObject {
         session = nil
         
         matrics.reset()
-    }
-    
-
-    private func readRoutes() {
-        guard let route else { return }
-        let query = HKWorkoutRouteQuery(route: route) { (query, locationsOrNil, done, errorOrNil) in
-
-            if let error = errorOrNil {
-                return
-            }
-
-            guard let locations = locationsOrNil else {
-                fatalError("*** Invalid State: This can only fail if there was an error. ***")
-            }
-
-            // Do something with this batch of location data.
-            // HealthKit에서 얻는 정확성 50m 혹은 그보다 적다고 합니다.
-            // 지도에 라인이나 점을 찍기에는 추가적인 작업이 필요하다네요.
-            // 여기서 locations를 찍어보면 돼요.
-
-            /* 예시
-             for loc in locations {
-                 print(loc.coordinate.latitude)
-                 print(loc.coordinate.longitude)
-             }
-             */
-        }
-        healthStore.execute(query)
     }
 }

--- a/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WatchWorkoutManager.swift
@@ -175,6 +175,7 @@ final class WorkoutManager: NSObject, ObservableObject {
     
     func endWorkout() {
         session?.end()
+        showingSummaryView.toggle()
     }
     
     // 두 부분으로 나누기

--- a/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WorkoutManager+extensions.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WorkoutManager+extensions.swift
@@ -23,10 +23,10 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
             Task { @MainActor in
                 do {
                     try await endWorkoutSession(date)
-                    self.showingSummaryView.toggle()
                 } catch {
                     NSLog(error.localizedDescription)
                 }
+                self.showingSummaryView.toggle()
             }
         }
     }

--- a/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WorkoutManager+extensions.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WorkoutManager+extensions.swift
@@ -26,7 +26,6 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
                 } catch {
                     NSLog(error.localizedDescription)
                 }
-                self.showingSummaryView.toggle()
             }
         }
     }


### PR DESCRIPTION
---
name: 구룡포 풀리퀘스트 템플릿입니다
about: 해당 템플릿을 사용하여 이슈를 생성해주세요.
title: "작업 타입: [#관련 이슈번호] 작업 내용"
labels: ''
assignees: ''
---
⚠️ labels, assigness 할당해주세요.

## 🐲 관련 이슈
close #358
close #351 

## 🏃‍♂️ 구현/변경 사항
- 운동 타입 축구로 하면 기존 데이터 중 안들어오는 것 발생해서 원래 `.running`으로 두었습니다.
- 애플 워치에서 수행되는 순서를 개선했습니다. 

## 📷 스크린샷

https://github.com/user-attachments/assets/45fa705b-d5ba-459e-b699-da61633da197




## ✏️  ETC


## 🙏To Reviewer
워치랑 폰에서 네비게이션 로직 한번 갈아 엎긴 해야겠네요.

너무 어려워요.