### PR TITLE
[Feat/gucci/358] 건강 권한, 레이저 

### DIFF
--- a/SoccerBeat/Common/Utiles/Color+extension.swift
+++ b/SoccerBeat/Common/Utiles/Color+extension.swift
@@ -109,7 +109,7 @@ extension ShapeStyle where Self == Color {
     
     static var matchDetailViewTitleColor: Self { .init(hex: 0xFF077E) }
     static var matchDetailViewSubTitleColor: Self { .init(hex: 0xB4B4B4) }
-    static var matchDetailViewAverageStatColor: Self { .init(hex: 0x00FFE0) }
+    static var matchDetailViewAverageStatColor: Self { .maxStrokeColor }
     
     static var raderMaximumColor: Self { .init(hex: 0x369EFF) }
     
@@ -120,7 +120,7 @@ extension ShapeStyle where Self == Color {
     // MARK: - MatchRecapView Graph
     static var averageFillColor: Self { .init(hex: 0x47FFFF, alpha: 0.5) }
     static var averageStokeColor: Self { .init(hex: 0x03FFE0) }
-    static var maxFillColor: Self { Color.clear }
+    static var maxFillColor: Self { .maxStrokeColor.opacity(0.5) }
     static var maxStrokeColor: Self { .init(hex: 0xFF007A, alpha: 0.7) }
 }
 

--- a/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WatchWorkoutManager.swift
+++ b/SoccerBeat/SoccerBeat Watch App/Sources/WorkoutManager/WatchWorkoutManager.swift
@@ -21,6 +21,7 @@ final class WorkoutManager: NSObject, ObservableObject {
         locationManager.delegate = self
         locationManager.allowsBackgroundLocationUpdates = true
         locationManager.requestWhenInUseAuthorization()
+        requestHealthAuthorization()
     }
 
     // 헬스킷 세션 기록용 빌더 선언
@@ -185,5 +186,19 @@ final class WorkoutManager: NSObject, ObservableObject {
         session = nil
         
         matrics.reset()
+    }
+
+    func requestHealthAuthorization() {
+        healthStore.requestAuthorization(toShare: typesToShare, read: typesToRead) { success, error in
+            guard let error else {
+                NSLog(error.debugDescription)
+                return
+            }
+            if success {
+
+            } else {
+                NSLog("Error in getting healthstore reading authorization. ")
+            }
+        }
     }
 }

--- a/SoccerBeat/SoccerBeat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,51 @@
+{
+  "originHash" : "29e8b2dfe315c1e40cb25219ef12184f81b1b2a221290121e80000967b0ef669",
+  "pins" : [
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "86e9185ef41c4238a93ad8efe61ddeb701e80bbf",
+        "version" : "5.19.5"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
+      "state" : {
+        "revision" : "5d462f7530677ae0c2b9510c26383aa25ba48751",
+        "version" : "3.1.1"
+      }
+    },
+    {
+      "identity" : "skeletonui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CSolanaM/SkeletonUI.git",
+      "state" : {
+        "revision" : "d5c8a4f62be6a631bd4fe1922505eb34e82e5b4e",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
+        "version" : "1.16.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -198,7 +198,8 @@ extension MatchListItemView {
         let recent = DataConverter.toLevels(workoutData)
         let average = DataConverter.toLevels(profileModel.averageAbility)
         
-        RadarChartView(averageDataPoints: recent, maximumDataPoints: average, limitValue: 2.5)
+//        RadarChartView(averageDataPoints: recent, maximumDataPoints: average, limitValue: 2.5)
+        RadarChartView(averageDataPoints: recent, limitValue: 2.5)
     }
     
     @ViewBuilder

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/RadarChartShape.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/RadarChartShape.swift
@@ -42,41 +42,30 @@ struct RadarChartShape: Shape {
 
 struct RadarChartView: View {
     let averageDataPoints: [Double]
-    let maximumDataPoints: [Double]
+//    let maximumDataPoints: [Double]
     
     let limitValue: Double
     
     var body: some View {
-        ZStack {
-            // MARK: - max line border
-            
-            // MARK: - 평균 데이터 레이어
-            RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
-                .fill(.averageFillColor)
-                .overlay(
-                    RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
-                        .stroke(style: StrokeStyle(lineWidth: 3.5, lineCap: .round, lineJoin: .round))
-                        .foregroundStyle(.averageStokeColor)
-                )
-            
-            // MARK: - 최고 데이터 레이어
-            RadarChartShape(dataPoints: maximumDataPoints, maxValue: limitValue)
-                .fill(.maxFillColor)
-                .overlay(
-                    RadarChartShape(dataPoints: maximumDataPoints, maxValue: limitValue)
-                        .stroke(style: StrokeStyle(lineWidth: 3.5, lineCap: .round, lineJoin: .round))
-                        .foregroundStyle(.maxStrokeColor)
-                )
-        }
+        // MARK: - 평균 데이터 레이어, MatchRecapView에서 현재 경기를 보여줌
+        RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
+            .fill(.averageFillColor)
+            .overlay(
+                RadarChartShape(dataPoints: averageDataPoints, maxValue: limitValue)
+                    .stroke(style: StrokeStyle(lineWidth: 3.5, lineCap: .round, lineJoin: .round))
+                    .foregroundStyle(.averageStokeColor)
+            )
         .rotationEffect(.degrees(-90))
     }
 }
 
 #Preview {
     let averageDataPoints = [0.7, 0.6, 0.8, 0.9, 1.0, 0.6]
-    let currentDataPoints = [1.0, 0.3, 0.4, 0.7, 0.4, 0.3]
     let maxValue = 1.0
     
-    return RadarChartView(averageDataPoints: averageDataPoints, maximumDataPoints: currentDataPoints, limitValue: maxValue)
- 
+    return RadarChartView(
+        averageDataPoints: averageDataPoints,
+        limitValue: maxValue
+    )
+
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/ViewControllers/DataConverter.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/ViewControllers/DataConverter.swift
@@ -129,7 +129,7 @@ final class DataConverter {
                                        totalMatchTime: workout.playtimeSec)
         
         
-        return toTriple(recentLevel)
+        return Amplify(recentLevel)
     }
     
     static func toLevels(_ averageWorkout: WorkoutAverageData) -> [Double] {
@@ -141,10 +141,10 @@ final class DataConverter {
                                              minHeartRate: averageWorkout.minHeartRate,
                                              rangeHeartRate: averageWorkout.maxHeartRate-averageWorkout.minHeartRate,
                                              totalMatchTime: averageWorkout.totalMatchTime)
-        return toTriple(averageLevel)
+        return Amplify(averageLevel)
     }
     
-    static private func toTriple(_ level: [String: Double]) -> [Double] {
+    static private func Amplify(_ level: [String: Double]) -> [Double] {
         return [
             (level["totalDistance"] ?? 1.0) * 0.15 + (level["maxHeartRate"] ?? 1.0) * 0.35,
             (level["maxVelocity"] ?? 1.0) * 0.3 + (level["maxPower"] ?? 1.0) * 0.2,
@@ -152,6 +152,8 @@ final class DataConverter {
             (level["maxPower"] ?? 1.0) * 0.4 + (level["minHeartRate"] ?? 1.0) * 0.1,
             (level["totalDistance"] ?? 1.0) * 0.15 + (level["rangeHeartRate"] ?? 1.0) * 0.15 + (level["totalMatchTime"] ?? 1.0) * 0.2,
             (level["totalDistance"] ?? 1.0) * 0.3 + (level["sprintCount"] ?? 1.0) * 0.1 + (level["maxHeartRate"] ?? 1.0) * 0.1
-        ]
+        ].map { value in
+            value * 1.5
+        }
     }
 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/ViewControllers/RadarViewController.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/ViewControllers/RadarViewController.swift
@@ -185,17 +185,21 @@ class ProfileViewController: UIViewController, TKRadarChartDataSource, TKRadarCh
     // Color of inside area of the graph.
     func colorOfSectionFillForRadarChart(_ radarChart: TKRadarChart, section: Int) -> UIColor {
         if section == 0 {
-            return UIColor(red:0.282,  green:1,  blue:1, alpha:0.5)
+            // average
+            return UIColor(.maxFillColor)
         } else {
+            // season high
             return UIColor.clear
         }
     }
     
     func colorOfSectionBorderForRadarChart(_ radarChart: TKRadarChart, section: Int) -> UIColor {
         if section == 0 {
-            return UIColor(red:0,  green:1,  blue:0.878, alpha:1)
+            // average
+            return UIColor(.maxStrokeColor)
         } else {
-            return UIColor(red:0.211,  green:0.619,  blue:1, alpha:1)
+            // season high
+            return UIColor(red:53 / 255.0,  green: 158.0 / 255.0,  blue: 255.0 / 255.0, alpha:1)
         }
     }
     

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -91,7 +91,7 @@ struct ProfileView: View {
                         HStack {
                             HStack(spacing: 0) {
                                 Text("")
-                                Text("민트색")
+                                Text("빨간색")
                                     .bold()
                                     .foregroundStyle(.matchDetailViewAverageStatColor)
                                 Text("은 경기 평균 능력치입니다.")
@@ -104,11 +104,12 @@ struct ProfileView: View {
                     let average = DataConverter.toLevels(profileModel.averageAbility)
                     let maximumAbility = DataConverter.toLevels(profileModel.maxAbility)
                     
-                    ViewControllerContainer(ProfileViewController(radarAverageValue: average, radarAtypicalValue: maximumAbility))
-                                            .fixedSize()
-                                            .frame(width: 304, height: 348)
-                                            .zIndex(-1)
-                    
+                    ViewControllerContainer(ProfileViewController(radarAverageValue: average,
+                                                                  radarAtypicalValue: maximumAbility))
+                    .fixedSize()
+                    .frame(width: 304, height: 348)
+                    .zIndex(-1)
+
                     Spacer()
                         .frame(height: 110)
                     


### PR DESCRIPTION
## 🐲 관련 이슈
close #358 

## 🏃‍♂️ 구현/변경 사항
- 워치에서 건강 권한 최초 첫실행에 물어봄
- 요약 레이더 뷰 이번 당해 경기만 보여줌
- 프로필뷰에서 빨간색 평균, 파란색 시즌 베스트


## 📷 스크린샷
![매치 요약뷰 민트색](https://github.com/user-attachments/assets/30c4506f-9621-469f-be77-512c540a525a)
![프로필뷰-파란색-빨간색](https://github.com/user-attachments/assets/e732bced-f0ab-4a5d-b721-4c29158de7f2)


## ✏️  ETC


## 🙏To Reviewer
