### PR TITLE
feat:[#383] ShareView button hidden

### DIFF
--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 
 struct ProfileView: View {
+    @State private var isBackButtonHidden = false
     @EnvironmentObject var profileModel: ProfileModel
     @State private var isFlipped = false
     @State private var userImage: UIImage?
@@ -124,7 +125,7 @@ struct ProfileView: View {
         }
         .toolbar {
             NavigationLink {
-                ShareView()
+                ShareView(isBackButtonHidden: $isBackButtonHidden)
             } label: {
                 Text("공유하기")
                     .foregroundStyle(.shareViewTitleTint)

--- a/SoccerBeat/SoccerBeat/Sources/Features/Share/ShareView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Share/ShareView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Photos
 
 struct ShareView: View {
+    @Binding var isBackButtonHidden: Bool
     @EnvironmentObject var profileModel: ProfileModel
     @EnvironmentObject var healthInteractor: HealthInteractor
     @State var degree: Double = 0
@@ -20,6 +21,7 @@ struct ShareView: View {
             .frame(maxHeight: UIScreen.screenHeight)
             VStack {
                 Spacer()
+                    .frame(height: 50)
                 HStack(alignment: .bottom) {
                     CardFront(degree: $degree, width: 100, height: 140)
                     VStack(alignment: .leading, spacing: 0) {
@@ -55,12 +57,20 @@ struct ShareView: View {
             }
             .padding()
         }
+        .navigationBarBackButtonHidden(isBackButtonHidden)
         .toolbar {
             Button {
-                share()
+                isBackButtonHidden = true
+                DispatchQueue.main.async {
+                            share()
+                        }
+                DispatchQueue.main.async {
+                    isBackButtonHidden = false
+                        }
             } label: {
                 Text("공유하기")
                     .foregroundStyle(.shareViewTitleTint)
+                    .opacity(isBackButtonHidden ? 0 : 1)
             }
         }
     }
@@ -108,13 +118,13 @@ extension ShareView {
     }
 
     private func share() {
-        guard let screenshot = UIWindow.screenshot() else { return }
+        guard let screenshot = ShareView.screenshot() else { return }
         let activityViewController = UIActivityViewController(activityItems: [screenshot], applicationActivities: nil)
         UIApplication.shared.windows.first?.rootViewController?.present(activityViewController, animated: true)
     }
 }
 
-extension UIWindow {
+extension ShareView {
     static func screenshot() -> UIImage? {
         guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return nil }
 
@@ -126,6 +136,6 @@ extension UIWindow {
 }
 
 #Preview {
-    ShareView()
+    ShareView(isBackButtonHidden: .constant(false))
         .environmentObject(ProfileModel(healthInteractor: HealthInteractor()))
 }


### PR DESCRIPTION
## 🐲 관련 이슈
close #383 

## 🏃‍♂️ 구현/변경 사항
- Toolbar(공유하기) 버튼을 누를 때 일시적으로 navigationbackbutton과 toolbar button이 보이지 않도록 각각 hidden과 opacity를 적용하였습니다.
- 스크린샷의 상단 여백을 줄이기 위해 높이를 조절하였습니다.

## 📷 스크린샷
![IMG_8DF6FCA9C85E-1](https://github.com/user-attachments/assets/e4c53e1e-cb3b-47f0-9dac-90c53bc81d30)


## ✏️  ETC


## 🙏To Reviewer
