### PR TITLE
feat: [#392] MatchRecapView Radar Chart 비율 조정

### DIFF
--- a/SoccerBeat/Common/Data/WorkoutData.swift
+++ b/SoccerBeat/Common/Data/WorkoutData.swift
@@ -121,9 +121,9 @@ struct WorkoutData: Hashable, Equatable, Identifiable {
     
     // TODO: - Factory Method Pattern으로 빼내는건 어떨까요?
     static let exampleWorkouts = [
-        WorkoutData(dataID: 1, date: "2023-10-09T01:20:32Z", time: "61:10", distance: 3.5, sprint: 3, velocity: 10.5, power: 3.0, heartRate: ["max": 171, "min": 53], route: [], center: [0, 0]),
-        WorkoutData(dataID: 2, date: "2023-10-09T01:20:35Z", time: "62:10", distance: 2.1, sprint: 5, velocity: 11.5, power: 3.0, heartRate: ["max": 152, "min": 70], route: [], center: [0, 0]),
-        WorkoutData(dataID: 3, date: "2023-10-09T01:20:38Z", time: "60:10", distance: 1.1, sprint: 7, velocity: 8.5, power: 3.0, heartRate: ["max": 167, "min": 92], route: [], center: [0, 0]),
+        WorkoutData(dataID: 1, date: "2023-10-09T01:20:32Z", time: "99:99", distance: 999.0, sprint: 999, velocity: 999.0, power: 999.0, heartRate: ["max": 999, "min": 1], route: [], center: [0, 0]),
+        WorkoutData(dataID: 2, date: "2023-10-09T01:20:35Z", time: "62:10", distance: 2.1, sprint: 5, velocity: 11.5, power: 32.0, heartRate: ["max": 152, "min": 70], route: [], center: [0, 0]),
+        WorkoutData(dataID: 3, date: "2023-10-09T01:20:38Z", time: "60:10", distance: 1.1, sprint: 7, velocity: 8.5, power: 97.0, heartRate: ["max": 167, "min": 92], route: [], center: [0, 0]),
         WorkoutData(dataID: 4, date: "2023-10-19T01:20:32Z", time: "60:10", distance: 5.1, sprint: 9, velocity: 12.5, power: 3.0, heartRate: ["max": 185, "min": 100], route: [], center: [0, 0]),
         WorkoutData(dataID: 5, date: "2023-10-20T01:20:32Z", time: "60:10", distance: 4.5, sprint: 11, velocity: 17.2, power: 3.0, heartRate: ["max": 175, "min": 60], route: [], center: [0, 0]),
         WorkoutData(dataID: 6, date: "2023-10-21T01:20:32Z", time: "60:10", distance: 3.6, sprint: 5, velocity: 24.4, power: 3.0, heartRate: ["max": 190, "min": 79], route: [], center: [0, 0]),

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -139,6 +139,7 @@ struct MatchListItemView: View {
             HStack(spacing: 0) {
                 // 스파이더 차트
                 radarCharts
+//                    .frame(width: 60, height: 60)
                     .padding(.top, 16)
                     .opacity(workoutData.error ? 0 : 1)
                 
@@ -199,8 +200,8 @@ extension MatchListItemView {
         let recent = DataConverter.toLevels(workoutData)
         let average = DataConverter.toLevels(profileModel.averageAbility)
         
-//        RadarChartView(averageDataPoints: recent, maximumDataPoints: average, limitValue: 2.5)
-        RadarChartView(averageDataPoints: recent, limitValue: 2.5)
+        RadarChartView(averageDataPoints: recent, limitValue: 5.0)
+
     }
     
     @ViewBuilder

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/ViewControllers/DataConverter.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/ViewControllers/DataConverter.swift
@@ -55,15 +55,15 @@ final class DataConverter {
             levels["maxVelocity"] = 5.0
         }
         
-        if maxPower <= 2.0 {
+        if maxPower <= 50.0 {
             levels["maxPower"] = 1.0
-        } else if maxPower > 2.0 && maxPower <= 3.0 {
+        } else if maxPower > 50.0 && maxPower <= 100.0 {
             levels["maxPower"] = 2.0
-        } else if maxPower > 3.0 && maxPower <= 4.0 {
+        } else if maxPower > 100.0 && maxPower <= 150.0 {
             levels["maxPower"] = 3.0
-        } else if maxPower > 4.0 && maxPower <= 5.0 {
+        } else if maxPower > 150.0 && maxPower <= 200.0 {
             levels["maxPower"] = 4.0
-        } else if maxPower > 5.0 {
+        } else if maxPower > 200.0 {
             levels["maxPower"] = 5.0
         }
         


### PR DESCRIPTION
## 🐲 관련 이슈
close #392 

## 🏃‍♂️ 구현/변경 사항
- RadarChart limitValue를 5.0으로 변경하여 하나의 프레임 밖으로 나가지 않도록 조정하였습니다.
- 일반적으로 power가 찍히는 범위가 80~200인 것으로 확인되어 toLevel 범위를 변경하였습니다.
- exampleWorkouts 첫 번째 인덱스를 최대값을 주어 범위 밖으로 나가지 않음을 확인했습니다.

## 📷 스크린샷
![IMG_1954](https://github.com/user-attachments/assets/2050d147-0fb5-404f-973c-a36b00707a4c)

<img width="245" alt="스크린샷 2024-08-17 오후 7 29 58" src="https://github.com/user-attachments/assets/5fe429bc-3635-462f-b7fd-8d51a35065fd">


## ✏️  ETC


## 🙏To Reviewer
