### PR TITLE
fix: [#405] Workout 두번 삭제하는 버그 수정

### DIFF
--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -105,7 +105,6 @@ struct MatchRecapView: View {
     }
     
     private func delete(_ offset: IndexSet) async {
-        workouts.remove(atOffsets: offset)
         do {
             try await healthInteractor.delete(at: offset)
         } catch {


### PR DESCRIPTION
## 🐲 관련 이슈
close #405 

## 🏃‍♂️ 구현/변경 사항
- 데이터 삭제가 두곳에서 되는 버그를 수정했습니다. 흑..

## 📷 스크린샷


## ✏️  ETC


## 🙏To Reviewer
