### PR TITLE
feat: #433 인앱리뷰 기능 구현

### DIFF
--- a/SoccerBeat/Common/Resource/Localizable.xcstrings
+++ b/SoccerBeat/Common/Resource/Localizable.xcstrings
@@ -2304,7 +2304,30 @@
         }
       }
     },
+    "네" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sí"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是的"
+          }
+        }
+      }
+    },
     "네!" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/SoccerBeat/Common/Resource/Localizable.xcstrings
+++ b/SoccerBeat/Common/Resource/Localizable.xcstrings
@@ -2304,6 +2304,28 @@
         }
       }
     },
+    "네!" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes!"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡Sí!"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是的！"
+          }
+        }
+      }
+    },
     "닉네임" : {
       "comment" : "닉네임",
       "extractionState" : "manual",
@@ -3042,6 +3064,28 @@
         }
       }
     },
+    "사커비트 앱이 마음에 드시나요?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do you love the SoccerBeat App?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Te encanta la aplicación SoccerBeat?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你喜欢 SoccerBeat 应用吗？"
+          }
+        }
+      }
+    },
     "사커비트를 사용하기 위해 권한을 설정해주세요." : {
       "comment" : "NoAuthorizationView Info Button",
       "extractionState" : "manual",
@@ -3502,6 +3546,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "心率"
+          }
+        }
+      }
+    },
+    "아니요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不是"
           }
         }
       }

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -6,11 +6,17 @@
 //
 
 import SwiftUI
+import StoreKit
 
 struct MatchRecapView: View {
     @EnvironmentObject var healthInteractor: HealthInteractor
     @State private var userName = ""
     @Binding var workouts: [WorkoutData]
+    @State private var requestReview = false
+    @State private var hasRequestedReviewBefore = false
+    @State private var hasDoneReview = false
+    private let reviewRequestThreshold: TimeInterval = 4 * 30 * 24 * 60 * 60 // 4 months
+    
     
     private var lastName: String {
         guard let lastName = userName
@@ -87,7 +93,7 @@ struct MatchRecapView: View {
                         .opacity(0.3)
                     VStack {
                         Text("저장된 경기 기록이 없습니다.")
-                        .font(.matchRecapEmptyDataTop)
+                            .font(.matchRecapEmptyDataTop)
                         Group {
                             Text("애플워치를 차고 사커비트로")
                             Text("당신의 첫 번째 경기를 기록해 보세요!")
@@ -99,8 +105,40 @@ struct MatchRecapView: View {
                 Spacer()
             }
         }
+        .alert(isPresented: $requestReview) {
+            Alert(title: Text("리뷰를 남겨주세요!"),
+                  message: Text("이 앱이 도움이 되었나요?"),
+                  primaryButton: .default(Text("네")) {
+                requestAppReview()
+                hasRequestedReviewBefore = true
+                UserDefaults.standard.set(Date(), forKey: "lastReviewReuquestDate")
+            },
+                  secondaryButton: .cancel() {
+                hasRequestedReviewBefore = true
+            })
+        }
         .onAppear {
             userName = UserDefaults.standard.string(forKey: "userName") ?? ""
+            
+            if let lastRequestDate = UserDefaults.standard.object(forKey: "lastReviewRequestDate") as? Date {
+                let timeSinceLastRequest = Date().timeIntervalSince(lastRequestDate)
+                
+                if timeSinceLastRequest > reviewRequestThreshold {
+                    if workouts.count > 7 && !hasRequestedReviewBefore {
+                        requestReview = true
+                    }
+                }
+            }
+            else if workouts.count > 7 && !hasRequestedReviewBefore {
+                requestReview = true
+            }
+        }
+    }
+    private func requestAppReview() {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            SKStoreReviewController.requestReview(in: windowScene)
+        } else {
+            SKStoreReviewController.requestReview()
         }
     }
     
@@ -138,7 +176,7 @@ struct MatchListItemView: View {
             HStack(spacing: 0) {
                 // 스파이더 차트
                 radarCharts
-//                    .frame(width: 60, height: 60)
+                //                    .frame(width: 60, height: 60)
                     .padding(.top, 16)
                     .opacity(workoutData.error ? 0 : 1)
                 
@@ -200,7 +238,7 @@ extension MatchListItemView {
         let average = DataConverter.toLevels(profileModel.averageAbility)
         
         RadarChartView(averageDataPoints: recent, limitValue: 5.0)
-
+        
     }
     
     @ViewBuilder

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -14,7 +14,6 @@ struct MatchRecapView: View {
     @Binding var workouts: [WorkoutData]
     @State private var requestReview = false
     @State private var hasRequestedReviewBefore = false
-    @State private var hasDoneReview = false
     private let reviewRequestThreshold: TimeInterval = 4 * 30 * 24 * 60 * 60 // 4 months
     
     
@@ -106,14 +105,13 @@ struct MatchRecapView: View {
             }
         }
         .alert(isPresented: $requestReview) {
-            Alert(title: Text("리뷰를 남겨주세요!"),
-                  message: Text("이 앱이 도움이 되었나요?"),
-                  primaryButton: .default(Text("네")) {
+            Alert(title: Text("사커비트 앱이 마음에 드시나요?"),
+                  primaryButton: .default(Text("네!")) {
                 requestAppReview()
                 hasRequestedReviewBefore = true
                 UserDefaults.standard.set(Date(), forKey: "lastReviewReuquestDate")
             },
-                  secondaryButton: .cancel() {
+                  secondaryButton: .cancel(Text("아니요")) {
                 hasRequestedReviewBefore = true
             })
         }

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -106,7 +106,7 @@ struct MatchRecapView: View {
         }
         .alert(isPresented: $requestReview) {
             Alert(title: Text("사커비트 앱이 마음에 드시나요?"),
-                  primaryButton: .default(Text("네!")) {
+                  primaryButton: .default(Text("네")) {
                 requestAppReview()
                 UserDefaults.standard.set(Date(), forKey: "lastReviewReuquestDate")
             },

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/MatchRecapView.swift
@@ -13,7 +13,7 @@ struct MatchRecapView: View {
     @State private var userName = ""
     @Binding var workouts: [WorkoutData]
     @State private var requestReview = false
-    @State private var hasRequestedReviewBefore = false
+    @State private var hasDoneReviewBefore = false
     private let reviewRequestThreshold: TimeInterval = 4 * 30 * 24 * 60 * 60 // 4 months
     
     
@@ -108,11 +108,10 @@ struct MatchRecapView: View {
             Alert(title: Text("사커비트 앱이 마음에 드시나요?"),
                   primaryButton: .default(Text("네!")) {
                 requestAppReview()
-                hasRequestedReviewBefore = true
                 UserDefaults.standard.set(Date(), forKey: "lastReviewReuquestDate")
             },
                   secondaryButton: .cancel(Text("아니요")) {
-                hasRequestedReviewBefore = true
+                UserDefaults.standard.set(Date(), forKey: "lastReviewReuquestDate")
             })
         }
         .onAppear {
@@ -122,12 +121,12 @@ struct MatchRecapView: View {
                 let timeSinceLastRequest = Date().timeIntervalSince(lastRequestDate)
                 
                 if timeSinceLastRequest > reviewRequestThreshold {
-                    if workouts.count > 7 && !hasRequestedReviewBefore {
+                    if workouts.count > 7 && !hasDoneReviewBefore {
                         requestReview = true
                     }
                 }
             }
-            else if workouts.count > 7 && !hasRequestedReviewBefore {
+            else if workouts.count > 7 && !hasDoneReviewBefore {
                 requestReview = true
             }
         }
@@ -138,6 +137,7 @@ struct MatchRecapView: View {
         } else {
             SKStoreReviewController.requestReview()
         }
+        hasDoneReviewBefore = true
     }
     
     private func delete(_ offset: IndexSet) async {


### PR DESCRIPTION
## 🐲 관련 이슈
close #433 

## 🏃‍♂️ 구현/변경 사항
- MatchRecapView에 인앱리뷰 구현하였습니다.
- 특정 로직을 거친 Alert를 통해 사커비트앱에 긍정적인 반응을 확인한 후, 긍정평가를 준 유저에게만 리뷰를 요청하도록 구현하였습니다.
- 로직 : 1) Workouts 개수가 7개 이상, 2) 이전에 리뷰를 작성한 적이 없거나 or 리뷰 요청을 받은 지 4개월이 지난 경우 -> 리뷰 요청 alert
- 로컬라이저블 적용했습니다.

## 📷 스크린샷
<img width="268" alt="image" src="https://github.com/user-attachments/assets/bd5cca87-e136-48d2-b05b-aaf485bf7613">
<img width="268" alt="image" src="https://github.com/user-attachments/assets/0412db32-c835-4bc5-9aa9-8128ca63435a">

![KakaoTalk_Photo_2024-10-01-22-24-44 001](https://github.com/user-attachments/assets/a727e482-792b-486c-9215-0b3153c87919)
![KakaoTalk_Photo_2024-10-01-22-24-44 002](https://github.com/user-attachments/assets/04cf49c8-5202-4ffe-a4af-18d6849a69c6)



## ✏️  ETC
- 다음은 제가 참고한 레퍼런스 중, 총 3단계로 리뷰를 요청하는 방법도 있습니다.

![image](https://github.com/user-attachments/assets/3ad2057e-36c6-49b6-87f9-167a670d45c1)
![image](https://github.com/user-attachments/assets/c6e22283-b577-4c1b-bd25-433c82d0582c)
![image](https://github.com/user-attachments/assets/8270aab9-144d-4ac3-a3c7-13b2e95443b3)


## 🙏To Reviewer
