### PR TITLE
feat: #446 padding 수정

### DIFF
--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -119,6 +119,7 @@ struct ProfileView: View {
                     TrophyCollectionView()
                     
                 }
+                .padding(.horizontal)
                 .onTapGesture {
                     hideKeyboard()
                 }

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/ProfileView.swift
@@ -28,7 +28,7 @@ struct ProfileView: View {
                                 .minimumScaleFactor(0.8)
                                 Spacer()
                             }
-                            .padding(.bottom, 30)
+                            .padding(.vertical, 30)
                             
                             VStack(spacing: 0) {
                                 HStack {

--- a/SoccerBeat/SoccerBeat/Sources/Features/Profile/Subviews/TrophyCollectionView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/Profile/Subviews/TrophyCollectionView.swift
@@ -23,10 +23,9 @@ struct TrophyCollectionView: View {
                     .font(.navigationSportyTitle)
                     .highlighter(activity: .sprint, isDefault: true)
             }
-            .padding(.horizontal, 10)
             
             trophyCollection
-                .padding(.horizontal, 16)
+                .padding(.horizontal, 6)
         }
     }
 }


### PR DESCRIPTION
## 🐲 관련 이슈
close #446 

## 🏃‍♂️ 구현/변경 사항
- 프로필뷰 좌측 패딩 수정했습니다.

## 📷 스크린샷
<img width="209" alt="image" src="https://github.com/user-attachments/assets/ab770a20-6dd5-4a31-9cf5-5a8d8c8e28a5">


## ✏️  ETC


## 🙏To Reviewer
