### PR TITLE
feat: 히트맵 범위 로직 변경

### DIFF
--- a/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
+++ b/SoccerBeat/SoccerBeat.xcodeproj/project.pbxproj
@@ -1159,8 +1159,7 @@
 				680567242CCA9D0D00DB0B4F /* ShapeStyle+extension.swift in Sources */,
 				680567272CCA9D3500DB0B4F /* View+extension.swift in Sources */,
 				BE0639D82AE61BC2008D1D4E /* SplitControlsView.swift in Sources */,
-				BEA63A672B0AFDFF000A309D /* ActivityEnum.swift in Sources */,
-				BE360F022BA016EA00071C30 /* WorkoutManager_Watch+extensions.swift in Sources */,
+				BE360F022BA016EA00071C30 /* WorkoutManager_Watch.swift in Sources */,
 				683825052B06249F00FE9CDF /* SprintSheetView.swift in Sources */,
 				6898F2852AEFD7FC0075A573 /* SprintView.swift in Sources */,
 				6820884C2AF11EB200F51A3E /* PrecountView.swift in Sources */,
@@ -1327,7 +1326,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SoccerBeat Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=watchos*]" = 8S86367NT3;
@@ -1347,7 +1346,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeat.Guryongpo.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1370,7 +1369,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SoccerBeat Watch App/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=watchos*]" = 8S86367NT3;
@@ -1390,7 +1389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeat.Guryongpo.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1440,7 +1439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeat.Guryongpo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1489,7 +1488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SoccerBeat.Guryongpo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/HeatmapView.swift
+++ b/SoccerBeat/SoccerBeat/Sources/Features/MatchRecords/Subviews/HeatmapView.swift
@@ -94,9 +94,11 @@ struct HeatmapView: UIViewRepresentable {
             }
         }
         
-        // Maximum number of data per grid
-        let maxCount = gridCount.flatMap { $0 }.max() ?? 1
-        
+        // Calculate maxCount and medianCount
+        let flatGridCount = gridCount.flatMap { $0 }
+        let maxCount = flatGridCount.max() ?? 1
+        let medianCount = flatGridCount.sorted()[flatGridCount.count / 2]
+                
         for row in 0..<gridSize+1 {
             for col in 0..<gridSize+1 {
                 
@@ -108,8 +110,8 @@ struct HeatmapView: UIViewRepresentable {
                 
                 let squareCenter = CLLocationCoordinate2D(latitude: coordinate.latitude, longitude: coordinate.longitude)
                 
-                //  Calculate ratio of number of data within a grid
-                let normalizedCount = Double(gridCount[row][col]) / Double(maxCount)
+                //  Calculate ratio of number of data using log function within a grid
+                let normalizedCount = normalizedCount(gridCount[row][col], maxCount: maxCount, medianCount: medianCount)
                 
                 let color = colorForNormalizedCount(normalizedCount)
                 
@@ -121,28 +123,43 @@ struct HeatmapView: UIViewRepresentable {
         return overlays
     }
     
+    // In order to handle unevenly distributed data, multiple scales are used.
+    // Linear scale
+    func normalizedCount(_ count: Int, maxCount: Int, medianCount: Int) -> Double {
+        if count == 0 || count == 1 {
+            return 0
+        }
+        if Double(maxCount) > Double(medianCount) * 5 {
+            // Log scale for skewed data
+            return log(Double(count) + 1) / log(Double(maxCount) + 1)
+        } else {
+            // Linear scale for evenly distributed data
+            return Double(count) / Double(maxCount)
+        }
+    }
+
     func colorForNormalizedCount(_ normalizedCount: Double) -> UIColor {
         
         switch normalizedCount {
-        case 0..<0.1:
+        case 0:
             return UIColor.clear
-        case 0.1..<0.2:
+        case 0..<0.05:
             return UIColor(Color.heatmap90)
-        case 0.2..<0.3:
+        case 0.05..<0.1:
             return UIColor(Color.heatmap80)
-        case 0.3..<0.4:
+        case 0.1..<0.2:
             return UIColor(Color.heatmap70)
-        case 0.4..<0.5:
+        case 0.2..<0.3:
             return UIColor(Color.heatmap60)
-        case 0.5..<0.6:
+        case 0.3..<0.4:
             return UIColor(Color.heatmap50)
-        case 0.6..<0.7:
+        case 0.4..<0.55:
             return UIColor(Color.heatmap40)
-        case 0.7..<0.8:
+        case 0.55..<0.7:
             return UIColor(Color.heatmap30)
-        case 0.8..<0.9:
+        case 0.7..<0.85:
             return UIColor(Color.heatmap20)
-        case 0.9...1.0:
+        case 0.85...1.0:
             return UIColor(Color.heatmap10)
         default:
             return UIColor.clear


### PR DESCRIPTION
## 🐲 관련 이슈
close #479 

## 🏃‍♂️ 구현/변경 사항
- 히트맵 그리는 로직을 선형 스케일 + 로그 스케일을 사용하는 것으로 변경하였습니다.
- 한 그리드 내에 데이터가 치우치는 현상을 보완하였습니다.

- 기존 : 선형 스케일, 0.0~1.0까지 0.1씩 균등 분배
- 현재 : 데이터가 치우친 경우는 로그 스케일, 균등한 경우에는 선형 스케일을 사용, 데이터 개수가 작은 구간은 더 세분화

## 📷 스크린샷
기존에 데이터가 치우친 경우 한 그리드만 표시되는 예시 사진입니다.
<img width="363" alt="image" src="https://github.com/user-attachments/assets/34a70e3c-8d16-451a-a856-ac97cceaee6e">


## ✏️  ETC


## 🙏To Reviewer
